### PR TITLE
feat(release): wire shipx release process for npm publish

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Lacy Morrow
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "paperclip-plugin-agent-usage",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paperclip-plugin-agent-usage",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@paperclipai/plugin-sdk": "latest"
       },
       "devDependencies": {
+        "@lacymorrow/shipx": "^0.1.0",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.8",
         "@types/react-dom": "^19.0.3",
@@ -22,6 +23,36 @@
       },
       "peerDependencies": {
         "react": ">=18"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.3.0.tgz",
+      "integrity": "sha512-xJPHpAmEQUBrXSLx0gF+q5K/IyihXpsHZcha+jB+tyahsKRK3Dxo4D0coZDewHo12NhiuzC3dTtMPbm53GEAAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.3.0.tgz",
+      "integrity": "sha512-GgcWwRCs/xPtaqlMy8qRhPnZf9vlWcWZNHAitnVQ3yk7JmSralSiq5q07yaffYE8SogtDm7zFeKccx1QNVARpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.3.0",
+        "fast-string-width": "^3.0.2",
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -466,6 +497,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/@lacymorrow/shipx": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@lacymorrow/shipx/-/shipx-0.1.0.tgz",
+      "integrity": "sha512-x2wYyL5Fe/3Jxj8qaWqrhQ0HszwMVcsFdJ575UIHy1Uz07jkuPH7VduBtZoRXp7IC9sNJ0gY83e8UpX9iJ5yDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clack/prompts": "^1.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "shipx": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@paperclipai/plugin-sdk": {
       "version": "2026.428.0",
       "resolved": "https://registry.npmjs.org/@paperclipai/plugin-sdk/-/plugin-sdk-2026.428.0.tgz",
@@ -575,6 +623,40 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/react": {
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
@@ -602,6 +684,13 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "main": "./dist/manifest.js",
   "exports": {
-    ".": "./dist/manifest.js"
+    ".": "./dist/manifest.js",
+    "./worker": "./dist/worker.js",
+    "./ui": "./dist/ui/index.js"
   },
   "files": [
     "dist/",

--- a/package.json
+++ b/package.json
@@ -1,42 +1,49 @@
 {
   "name": "paperclip-plugin-agent-usage",
-  "publishConfig": {
-    "access": "public"
-  },
   "version": "0.1.2",
   "description": "Track AI provider usage (Claude, etc.) and expose quota data to agents and the Paperclip dashboard",
   "type": "module",
+  "main": "./dist/manifest.js",
+  "exports": {
+    ".": "./dist/manifest.js"
+  },
+  "files": [
+    "dist/",
+    "README.md",
+    "LICENSE"
+  ],
   "paperclipPlugin": {
     "manifest": "./dist/manifest.js",
     "worker": "./dist/worker.js",
     "ui": "./dist/ui/"
   },
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
   "scripts": {
     "build": "node ./scripts/build.mjs",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
+    "dev": "node ./scripts/build.mjs --watch",
     "prepublishOnly": "npm run build",
-    "dev": "node ./scripts/build.mjs --watch"
+    "release": "shipx",
+    "release:beta": "shipx --beta"
   },
   "dependencies": {
     "@paperclipai/plugin-sdk": "latest"
   },
   "devDependencies": {
-    "esbuild": "^0.25.0",
+    "@lacymorrow/shipx": "^0.1.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
+    "esbuild": "^0.25.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "typescript": "^5.7.3"
   },
   "peerDependencies": {
     "react": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "keywords": [
     "paperclip",
@@ -46,7 +53,7 @@
     "anthropic"
   ],
   "license": "MIT",
-  "author": "Paperclip Company",
+  "author": "Lacy Morrow <lacy@lacymorrow.com>",
   "repository": {
     "type": "git",
     "url": "https://github.com/lacymorrow/paperclip-plugin-agent-usage"

--- a/shipx.config.ts
+++ b/shipx.config.ts
@@ -1,0 +1,17 @@
+import type { ShipConfig } from "@lacymorrow/shipx";
+
+export default {
+  steps: {
+    npm: true,
+    githubRelease: true,
+    homebrew: false,
+  },
+  git: {
+    releaseBranch: "main",
+    tagPrefix: "v",
+    commitMessage: "release: {tag}",
+  },
+  npm: {
+    access: "public",
+  },
+} satisfies ShipConfig;


### PR DESCRIPTION
## Summary

- [LAC-736](https://paperclip.so/issues/LAC-736) — Wire release process for paperclip-plugin-agent-usage

Wires up the `@lacymorrow/shipx` release CLI as the release tool for this plugin:

- **`@lacymorrow/shipx`** added as dev dependency — interactive release CLI (bump, tag, publish, GitHub release)
- **`release` / `release:beta`** scripts added (`shipx` / `shipx --beta`)
- **`prepublishOnly`** runs `npm run build` before any publish
- **`shipx.config.ts`** — npm public access, GitHub release enabled, Homebrew disabled
- **`LICENSE`** — MIT license file added
- **`files`** field — `dist/`, `README.md`, `LICENSE`
- **`publishConfig`** — `access: public` for Lacy's personal npm account
- **`main` / `exports`** — both point to `./dist/manifest.js`

## Test plan

- [ ] `npm run build` passes (verified locally)
- [ ] `npm run release` launches shipx interactive CLI
- [ ] `npm run release:beta` launches shipx with `--beta` tag
- [ ] `prepublishOnly` triggers build before publish
- [ ] `npm pack --dry-run` includes correct files (dist/, README.md, LICENSE)