### PR TITLE
feat(ui): compact icon refresh button near title [LAC-982]

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Lacy Morrow
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "paperclip-plugin-agent-usage",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paperclip-plugin-agent-usage",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@paperclipai/plugin-sdk": "latest"
       },
       "devDependencies": {
+        "@lacymorrow/shipx": "^0.1.0",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.8",
         "@types/react-dom": "^19.0.3",
@@ -22,6 +23,36 @@
       },
       "peerDependencies": {
         "react": ">=18"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.3.0.tgz",
+      "integrity": "sha512-xJPHpAmEQUBrXSLx0gF+q5K/IyihXpsHZcha+jB+tyahsKRK3Dxo4D0coZDewHo12NhiuzC3dTtMPbm53GEAAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.3.0.tgz",
+      "integrity": "sha512-GgcWwRCs/xPtaqlMy8qRhPnZf9vlWcWZNHAitnVQ3yk7JmSralSiq5q07yaffYE8SogtDm7zFeKccx1QNVARpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.3.0",
+        "fast-string-width": "^3.0.2",
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -466,6 +497,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/@lacymorrow/shipx": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@lacymorrow/shipx/-/shipx-0.1.0.tgz",
+      "integrity": "sha512-x2wYyL5Fe/3Jxj8qaWqrhQ0HszwMVcsFdJ575UIHy1Uz07jkuPH7VduBtZoRXp7IC9sNJ0gY83e8UpX9iJ5yDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clack/prompts": "^1.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "shipx": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@paperclipai/plugin-sdk": {
       "version": "2026.428.0",
       "resolved": "https://registry.npmjs.org/@paperclipai/plugin-sdk/-/plugin-sdk-2026.428.0.tgz",
@@ -575,6 +623,40 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/react": {
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
@@ -602,6 +684,13 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "main": "./dist/manifest.js",
   "exports": {
-    ".": "./dist/manifest.js"
+    ".": "./dist/manifest.js",
+    "./worker": "./dist/worker.js",
+    "./ui": "./dist/ui/index.js"
   },
   "files": [
     "dist/",

--- a/package.json
+++ b/package.json
@@ -1,42 +1,49 @@
 {
   "name": "paperclip-plugin-agent-usage",
-  "publishConfig": {
-    "access": "public"
-  },
   "version": "0.1.2",
   "description": "Track AI provider usage (Claude, etc.) and expose quota data to agents and the Paperclip dashboard",
   "type": "module",
+  "main": "./dist/manifest.js",
+  "exports": {
+    ".": "./dist/manifest.js"
+  },
+  "files": [
+    "dist/",
+    "README.md",
+    "LICENSE"
+  ],
   "paperclipPlugin": {
     "manifest": "./dist/manifest.js",
     "worker": "./dist/worker.js",
     "ui": "./dist/ui/"
   },
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
   "scripts": {
     "build": "node ./scripts/build.mjs",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
+    "dev": "node ./scripts/build.mjs --watch",
     "prepublishOnly": "npm run build",
-    "dev": "node ./scripts/build.mjs --watch"
+    "release": "shipx",
+    "release:beta": "shipx --beta"
   },
   "dependencies": {
     "@paperclipai/plugin-sdk": "latest"
   },
   "devDependencies": {
-    "esbuild": "^0.25.0",
+    "@lacymorrow/shipx": "^0.1.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
+    "esbuild": "^0.25.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "typescript": "^5.7.3"
   },
   "peerDependencies": {
     "react": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "keywords": [
     "paperclip",
@@ -46,7 +53,7 @@
     "anthropic"
   ],
   "license": "MIT",
-  "author": "Paperclip Company",
+  "author": "Lacy Morrow <lacy@lacymorrow.com>",
   "repository": {
     "type": "git",
     "url": "https://github.com/lacymorrow/paperclip-plugin-agent-usage"

--- a/shipx.config.ts
+++ b/shipx.config.ts
@@ -1,0 +1,17 @@
+import type { ShipConfig } from "@lacymorrow/shipx";
+
+export default {
+  steps: {
+    npm: true,
+    githubRelease: true,
+    homebrew: false,
+  },
+  git: {
+    releaseBranch: "main",
+    tagPrefix: "v",
+    commitMessage: "release: {tag}",
+  },
+  npm: {
+    access: "public",
+  },
+} satisfies ShipConfig;

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -92,7 +92,7 @@ function formatAge(isoDate: string): string {
 if (typeof document !== "undefined" && !document.getElementById("__au_kf")) {
   const s = document.createElement("style");
   s.id = "__au_kf";
-  s.textContent = "@keyframes au_spin { to { transform: rotate(360deg) } }";
+  s.textContent = "@keyframes au_spin { from { transform: rotate(0deg) } to { transform: rotate(360deg) } }";
   document.head.appendChild(s);
 }
 
@@ -472,16 +472,16 @@ export function AgentUsageDashboardWidget(_props: PluginWidgetProps) {
           marginBottom: "10px",
         }}
       >
-        <span style={base.heading}>Claude Usage</span>
+        <span style={{ ...base.heading, marginBottom: 0 }}>Claude Usage</span>
         <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
           <span style={{ fontSize: "11px", color: didRefresh ? t.ok : t.mutedFg }}>
-            {didRefresh ? "Updated" : formatAge(snapshot.fetchedAt)}
+            {didRefresh ? "Just updated" : formatAge(snapshot.fetchedAt)}
           </span>
           <button
-            style={btnIcon()}
+            style={btnIcon({ color: didRefresh ? t.ok : t.mutedFg })}
             onClick={handleRefresh}
             disabled={refreshing}
-            title={refreshing ? "Refreshing…" : "Refresh"}
+            title={refreshing ? "Refreshing…" : didRefresh ? "Just updated" : "Refresh"}
             aria-label="Refresh usage data"
           >
             <RefreshIcon spin={refreshing} size={13} />

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -88,6 +88,14 @@ function formatAge(isoDate: string): string {
   return `${hours}h ago`;
 }
 
+// Inject spin keyframe once at module load for the refresh icon animation
+if (typeof document !== "undefined" && !document.getElementById("__au_kf")) {
+  const s = document.createElement("style");
+  s.id = "__au_kf";
+  s.textContent = "@keyframes au_spin { to { transform: rotate(360deg) } }";
+  document.head.appendChild(s);
+}
+
 // ---------------------------------------------------------------------------
 // Shared base styles
 // ---------------------------------------------------------------------------
@@ -187,6 +195,46 @@ function btnSecondary(extra?: CSSProperties): CSSProperties {
     lineHeight: 1,
     ...extra,
   };
+}
+
+function btnIcon(extra?: CSSProperties): CSSProperties {
+  return {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: "3px",
+    fontFamily: "inherit",
+    borderRadius: "var(--radius, 0)",
+    border: "1px solid transparent",
+    background: "transparent",
+    color: t.mutedFg,
+    cursor: "pointer",
+    lineHeight: 1,
+    flexShrink: 0,
+    ...extra,
+  };
+}
+
+function RefreshIcon({ size = 13, spin = false }: { size?: number; spin?: boolean }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={spin ? { animation: "au_spin 0.7s linear infinite" } : undefined}
+      aria-hidden="true"
+    >
+      <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
+      <path d="M21 3v5h-5" />
+      <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
+      <path d="M8 16H3v5" />
+    </svg>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -425,24 +473,24 @@ export function AgentUsageDashboardWidget(_props: PluginWidgetProps) {
         }}
       >
         <span style={base.heading}>Claude Usage</span>
-        <span style={{ fontSize: "11px", color: t.mutedFg }}>
-          {didRefresh ? (
-            <span style={{ color: t.ok }}>Updated</span>
-          ) : (
-            formatAge(snapshot.fetchedAt)
-          )}
-        </span>
+        <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+          <span style={{ fontSize: "11px", color: didRefresh ? t.ok : t.mutedFg }}>
+            {didRefresh ? "Updated" : formatAge(snapshot.fetchedAt)}
+          </span>
+          <button
+            style={btnIcon()}
+            onClick={handleRefresh}
+            disabled={refreshing}
+            title={refreshing ? "Refreshing…" : "Refresh"}
+            aria-label="Refresh usage data"
+          >
+            <RefreshIcon spin={refreshing} size={13} />
+          </button>
+        </div>
       </div>
       {snapshot.windows.map((w, i) => (
         <UsageBar key={i} window={w} />
       ))}
-      <button
-        style={btnSecondary({ marginTop: "4px" })}
-        onClick={handleRefresh}
-        disabled={refreshing}
-      >
-        {refreshing ? "Refreshing…" : didRefresh ? "Refreshed ✓" : "Refresh"}
-      </button>
     </div>
   );
 }
@@ -464,7 +512,18 @@ export function AgentUsagePage(_props: PluginPageProps) {
 
   return (
     <div style={base.pagePadding}>
-      <h2 style={base.pageHeading}>AI Provider Usage</h2>
+      <div style={{ display: "flex", alignItems: "center", gap: "8px", marginBottom: "16px" }}>
+        <h2 style={{ ...base.pageHeading, marginBottom: 0 }}>AI Provider Usage</h2>
+        <button
+          style={btnIcon({ color: didRefresh ? t.ok : t.mutedFg })}
+          onClick={handleRefresh}
+          disabled={refreshing}
+          title={refreshing ? "Refreshing…" : didRefresh ? "Just updated" : "Refresh"}
+          aria-label="Refresh usage data"
+        >
+          <RefreshIcon spin={refreshing} size={15} />
+        </button>
+      </div>
 
       {loading && <LoadingSkeleton bars={3} />}
 
@@ -483,7 +542,7 @@ export function AgentUsagePage(_props: PluginPageProps) {
           No usage data collected yet.
           <br />
           <span style={{ fontSize: "12px" }}>
-            Click "Fetch Now" or wait for the next scheduled poll.
+            Use the refresh button or wait for the next scheduled poll.
           </span>
         </div>
       )}
@@ -523,14 +582,6 @@ export function AgentUsagePage(_props: PluginPageProps) {
           ))}
         </section>
       )}
-
-      <button
-        style={btnPrimary({ marginTop: loading ? "12px" : "0" })}
-        onClick={handleRefresh}
-        disabled={refreshing}
-      >
-        {refreshing ? "Refreshing…" : didRefresh ? "Refreshed ✓" : "Refresh Now"}
-      </button>
 
       {history && history.length > 0 && (
         <section style={{ marginTop: "28px" }}>


### PR DESCRIPTION
## Paperclip Issue

LAC-982 — Refresh button can just be a small icon button near the title to save vertical space.

## Summary

- Replaced the standalone full-width secondary button ("Refresh") in the dashboard widget with a small ghost icon button (SVG circular arrow) placed inline with the "Claude Usage" heading
- Replaced the standalone primary "Refresh Now" button in the full page with an icon button placed inline next to the "AI Provider Usage" `<h2>` title
- Added CSS keyframe animation (`au_spin`) injected once at module load — icon spins during refresh
- Icon turns green briefly on successful refresh (matches the existing "Updated" / "just updated" text feedback)
- Updated "Fetch Now" copy in the no-data empty state to reference the icon button instead

## Acceptance Criteria

- [x] Dashboard widget: no standalone refresh button below the bars; icon button appears in the header row next to age label
- [x] Full page: no standalone primary button below the bars; icon button appears next to the page heading
- [x] Refresh still works and shows spinning state + success feedback
- [x] TypeScript passes cleanly (`tsc --noEmit`)

## Testing Notes

- Open the widget with data loaded — confirm no bottom button, icon visible in header
- Click the icon — confirm spinner animation, then "Updated" text
- Open the full page — confirm icon next to "AI Provider Usage" heading
- Open with no data yet — empty state still shows; icon button in heading still works