### PR TITLE
fix(shipx): update manifest version and configure bumpFiles [LAC-1064]

### DIFF
--- a/shipx.config.ts
+++ b/shipx.config.ts
@@ -14,4 +14,11 @@ export default {
   npm: {
     access: "public",
   },
+  bumpFiles: [
+    {
+      path: "src/constants.ts",
+      pattern: /PLUGIN_VERSION = "[^"]+"/,
+      replacement: (v: string) => `PLUGIN_VERSION = "${v}"`,
+    },
+  ],
 } satisfies ShipConfig;

--- a/shipx.config.ts
+++ b/shipx.config.ts
@@ -17,7 +17,7 @@ export default {
   bumpFiles: [
     {
       path: "src/constants.ts",
-      pattern: /PLUGIN_VERSION = "[^"]+"/,
+      pattern: /PLUGIN_VERSION\s*=\s*["'][^"']+["']/,
       replacement: (v: string) => `PLUGIN_VERSION = "${v}"`,
     },
   ],

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 export const PLUGIN_ID = "paperclip-plugin-agent-usage";
-export const PLUGIN_VERSION = "0.1.0";
+export const PLUGIN_VERSION = "0.1.3";
 export const PAGE_ROUTE = "agent-usage";
 
 export const SLOT_IDS = {


### PR DESCRIPTION
## Summary

- https://app.paperclip.sh/issues/LAC-1064
- `PLUGIN_VERSION` in `src/constants.ts` was hardcoded at `0.1.0` while `package.json` had advanced to `0.1.3` — shipx was bumping `package.json` but not the constant used in the plugin manifest
- Added a `bumpFiles` entry to `shipx.config.ts` so future `shipx` runs regex-replace `PLUGIN_VERSION` in `src/constants.ts` to keep them in sync
- Manually synced `PLUGIN_VERSION` to the current `0.1.3` to fix the drift

## Test Plan

- [ ] Run `npm run release` (or `shipx` directly) and verify both `package.json` and `src/constants.ts` are updated with the new version
- [ ] Confirm the built manifest exports the correct `version` field matching `package.json`