### PR TITLE
fix(oauth): remove manual token setting, add auto-refresh [LAC-1073]

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A [Paperclip](https://docs.paperclip.ing) plugin that tracks AI provider usage q
 - **Full usage page** — detailed view with usage history table
 - **Agent tools** — `get-usage` and `get-usage-summary` let agents check remaining capacity before expensive operations
 - **Scheduled polling** — fetches usage every 15 minutes (configurable)
-- **Auto-detection** — reads Claude OAuth token from local credentials or macOS Keychain
+- **Auto-detection** — reads and auto-refreshes Claude OAuth token from local credentials or macOS Keychain
 - **Reset times** — shows when each quota window resets
 
 ## Supported Providers
@@ -35,9 +35,10 @@ POST /api/plugins/install
 
 | Field | Description | Default |
 |-------|-------------|---------|
-| `claudeOauthToken` | OAuth token for Anthropic usage API. Leave blank for auto-detect. | `""` |
 | `pollIntervalMinutes` | How often to refresh usage data | `15` |
 | `providers` | Which providers to track | `["claude"]` |
+
+OAuth credentials are auto-detected from your local Claude installation (`~/.claude` credentials or macOS Keychain). Expired tokens are refreshed automatically.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A [Paperclip](https://docs.paperclip.ing) plugin that tracks AI provider usage q
 - **Full usage page** — detailed view with usage history table
 - **Agent tools** — `get-usage` and `get-usage-summary` let agents check remaining capacity before expensive operations
 - **Scheduled polling** — fetches usage every 15 minutes (configurable)
-- **Auto-detection** — reads and auto-refreshes Claude OAuth token from local credentials or macOS Keychain
+- **Auto-detection** — reads Claude OAuth token from local credentials or macOS Keychain
 - **Reset times** — shows when each quota window resets
 
 ## Supported Providers
@@ -38,7 +38,7 @@ POST /api/plugins/install
 | `pollIntervalMinutes` | How often to refresh usage data | `15` |
 | `providers` | Which providers to track | `["claude"]` |
 
-OAuth credentials are auto-detected from your local Claude installation (`~/.claude` credentials or macOS Keychain). Expired tokens are refreshed automatically.
+OAuth credentials are auto-detected from your local Claude installation (`~/.claude` credentials or macOS Keychain). Token lifecycle is managed by Paperclip.
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "paperclip-plugin-agent-usage",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paperclip-plugin-agent-usage",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@paperclipai/plugin-sdk": "latest"

--- a/shipx.config.ts
+++ b/shipx.config.ts
@@ -14,4 +14,11 @@ export default {
   npm: {
     access: "public",
   },
+  bumpFiles: [
+    {
+      path: "src/constants.ts",
+      pattern: /PLUGIN_VERSION = "[^"]+"/,
+      replacement: (v: string) => `PLUGIN_VERSION = "${v}"`,
+    },
+  ],
 } satisfies ShipConfig;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -30,7 +30,6 @@ export const STATE_KEYS = {
 } as const;
 
 export const DEFAULT_CONFIG = {
-  claudeOauthToken: "",
   pollIntervalMinutes: 15,
   providers: ["claude"] as string[],
 } as const;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 export const PLUGIN_ID = "paperclip-plugin-agent-usage";
-export const PLUGIN_VERSION = "0.1.0";
+export const PLUGIN_VERSION = "0.1.3";
 export const PAGE_ROUTE = "agent-usage";
 
 export const SLOT_IDS = {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -40,13 +40,6 @@ const manifest: PaperclipPluginManifestV1 = {
   instanceConfigSchema: {
     type: "object",
     properties: {
-      claudeOauthToken: {
-        type: "string",
-        title: "Claude OAuth Token",
-        description:
-          "OAuth access token for the Anthropic usage API. Found in ~/.claude/.credentials.json under claudeAiOauth.accessToken. Leave blank to auto-detect from the local machine.",
-        default: DEFAULT_CONFIG.claudeOauthToken,
-      },
       pollIntervalMinutes: {
         type: "number",
         title: "Poll Interval (minutes)",

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -730,7 +730,7 @@ export function AgentUsageSettingsPage(_props: PluginSettingsPageProps) {
     <div style={base.container}>
       <h3 style={base.heading}>Agent Usage Status</h3>
       <p style={{ fontSize: "12px", color: t.mutedFg, marginBottom: "12px", marginTop: 0 }}>
-        Configure credentials and polling interval via the plugin settings above.
+        OAuth credentials are auto-detected from your local Claude installation.
       </p>
 
       <div

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -173,117 +173,21 @@ async function fetchAnthropicUsage(token: string): Promise<QuotaWindow[]> {
 // Token resolution (auto-detect from local ~/.claude credentials)
 // ---------------------------------------------------------------------------
 
-interface OAuthCredentials {
-  accessToken: string;
-  refreshToken?: string;
-  expiresAt?: number;
-}
-
-const OAUTH_TOKEN_ENDPOINT = "https://platform.claude.com/v1/oauth/token";
-const OAUTH_CLIENT_ID = "https://claude.ai/oauth/claude-code-client-metadata";
-const TOKEN_EXPIRY_BUFFER_MS = 5 * 60 * 1000;
-
 function claudeConfigDir(): string {
   const fromEnv = process.env.CLAUDE_CONFIG_DIR;
   if (typeof fromEnv === "string" && fromEnv.trim().length > 0) return fromEnv.trim();
   return path.join(os.homedir(), ".claude");
 }
 
-function extractOAuthCredentials(parsed: Record<string, unknown>): OAuthCredentials | null {
-  const oauth = parsed["claudeAiOauth"] as Record<string, unknown> | undefined;
-  const accessToken = oauth?.["accessToken"];
-  if (typeof accessToken !== "string" || accessToken.length === 0) return null;
-  return {
-    accessToken,
-    refreshToken: typeof oauth?.["refreshToken"] === "string" ? oauth["refreshToken"] as string : undefined,
-    expiresAt: typeof oauth?.["expiresAt"] === "number" ? oauth["expiresAt"] as number : undefined,
-  };
-}
-
-function isTokenExpired(creds: OAuthCredentials): boolean {
-  if (creds.expiresAt == null) return false;
-  return Date.now() >= creds.expiresAt - TOKEN_EXPIRY_BUFFER_MS;
-}
-
-async function refreshOAuthToken(refreshToken: string): Promise<OAuthCredentials | null> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 8000);
-  try {
-    const resp = await fetch(OAUTH_TOKEN_ENDPOINT, {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: new URLSearchParams({
-        grant_type: "refresh_token",
-        refresh_token: refreshToken,
-        client_id: OAUTH_CLIENT_ID,
-      }),
-      signal: controller.signal,
-    });
-    if (!resp.ok) return null;
-    const body = (await resp.json()) as Record<string, unknown>;
-    const accessToken = body["access_token"];
-    if (typeof accessToken !== "string" || accessToken.length === 0) return null;
-    const expiresIn = typeof body["expires_in"] === "number" ? body["expires_in"] as number : undefined;
-    return {
-      accessToken,
-      refreshToken: typeof body["refresh_token"] === "string" ? body["refresh_token"] as string : refreshToken,
-      expiresAt: expiresIn ? Date.now() + expiresIn * 1000 : undefined,
-    };
-  } catch {
-    return null;
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
-async function persistRefreshedCredentials(creds: OAuthCredentials): Promise<void> {
-  if (process.platform === "darwin") {
-    try {
-      const { stdout } = await execFileAsync("security", [
-        "find-generic-password", "-s", "Claude Code-credentials", "-w",
-      ], { timeout: 3000 });
-      const parsed = JSON.parse(stdout.trim()) as Record<string, unknown>;
-      const oauth = (parsed["claudeAiOauth"] ?? {}) as Record<string, unknown>;
-      oauth["accessToken"] = creds.accessToken;
-      if (creds.refreshToken) oauth["refreshToken"] = creds.refreshToken;
-      if (creds.expiresAt) oauth["expiresAt"] = creds.expiresAt;
-      parsed["claudeAiOauth"] = oauth;
-      const updated = JSON.stringify(parsed);
-      await execFileAsync("security", [
-        "add-generic-password", "-U", "-s", "Claude Code-credentials", "-w", updated, "-a", os.userInfo().username,
-      ], { timeout: 3000 });
-    } catch {
-      // Best-effort — CLI fallback still works
-    }
-  }
-
-  const configDir = claudeConfigDir();
-  for (const filename of [".credentials.json", "credentials.json"]) {
-    const filePath = path.join(configDir, filename);
-    try {
-      const raw = await fs.readFile(filePath, "utf8");
-      const parsed = JSON.parse(raw) as Record<string, unknown>;
-      const oauth = (parsed["claudeAiOauth"] ?? {}) as Record<string, unknown>;
-      oauth["accessToken"] = creds.accessToken;
-      if (creds.refreshToken) oauth["refreshToken"] = creds.refreshToken;
-      if (creds.expiresAt) oauth["expiresAt"] = creds.expiresAt;
-      parsed["claudeAiOauth"] = oauth;
-      await fs.writeFile(filePath, JSON.stringify(parsed, null, 2), "utf8");
-      return;
-    } catch {
-      // continue
-    }
-  }
-}
-
-async function readLocalClaudeCredentials(): Promise<OAuthCredentials | null> {
+async function readLocalClaudeToken(): Promise<string | null> {
   const configDir = claudeConfigDir();
   for (const filename of [".credentials.json", "credentials.json"]) {
     try {
       const raw = await fs.readFile(path.join(configDir, filename), "utf8");
       const parsed = JSON.parse(raw) as Record<string, unknown>;
-      const creds = extractOAuthCredentials(parsed);
-      if (creds) return creds;
+      const oauth = parsed["claudeAiOauth"] as Record<string, unknown> | undefined;
+      const token = oauth?.["accessToken"];
+      if (typeof token === "string" && token.length > 0) return token;
     } catch {
       // continue
     }
@@ -298,27 +202,11 @@ async function readLocalClaudeCredentials(): Promise<OAuthCredentials | null> {
         "-w",
       ], { timeout: 3000 });
       const parsed = JSON.parse(stdout.trim()) as Record<string, unknown>;
-      const creds = extractOAuthCredentials(parsed);
-      if (creds) return creds;
+      const oauth = parsed["claudeAiOauth"] as Record<string, unknown> | undefined;
+      const token = oauth?.["accessToken"];
+      if (typeof token === "string" && token.length > 0) return token;
     } catch {
       // continue
-    }
-  }
-
-  return null;
-}
-
-async function resolveValidToken(): Promise<string | null> {
-  const creds = await readLocalClaudeCredentials();
-  if (!creds) return null;
-
-  if (!isTokenExpired(creds)) return creds.accessToken;
-
-  if (creds.refreshToken) {
-    const refreshed = await refreshOAuthToken(creds.refreshToken);
-    if (refreshed) {
-      await persistRefreshedCredentials(refreshed);
-      return refreshed.accessToken;
     }
   }
 
@@ -504,7 +392,7 @@ async function pollAndStore(ctx: PluginContext): Promise<ProviderSnapshot> {
 
   let snapshot: ProviderSnapshot;
   try {
-    const token = await resolveValidToken();
+    const token = await readLocalClaudeToken();
     let windows: QuotaWindow[];
     let source: string;
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -43,7 +43,6 @@ interface UsageHistoryEntry {
 }
 
 interface PluginConfig {
-  claudeOauthToken?: string;
   pollIntervalMinutes?: number;
   providers?: string[];
 }
@@ -174,21 +173,117 @@ async function fetchAnthropicUsage(token: string): Promise<QuotaWindow[]> {
 // Token resolution (auto-detect from local ~/.claude credentials)
 // ---------------------------------------------------------------------------
 
+interface OAuthCredentials {
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt?: number;
+}
+
+const OAUTH_TOKEN_ENDPOINT = "https://platform.claude.com/v1/oauth/token";
+const OAUTH_CLIENT_ID = "https://claude.ai/oauth/claude-code-client-metadata";
+const TOKEN_EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+
 function claudeConfigDir(): string {
   const fromEnv = process.env.CLAUDE_CONFIG_DIR;
   if (typeof fromEnv === "string" && fromEnv.trim().length > 0) return fromEnv.trim();
   return path.join(os.homedir(), ".claude");
 }
 
-async function readLocalClaudeToken(): Promise<string | null> {
+function extractOAuthCredentials(parsed: Record<string, unknown>): OAuthCredentials | null {
+  const oauth = parsed["claudeAiOauth"] as Record<string, unknown> | undefined;
+  const accessToken = oauth?.["accessToken"];
+  if (typeof accessToken !== "string" || accessToken.length === 0) return null;
+  return {
+    accessToken,
+    refreshToken: typeof oauth?.["refreshToken"] === "string" ? oauth["refreshToken"] as string : undefined,
+    expiresAt: typeof oauth?.["expiresAt"] === "number" ? oauth["expiresAt"] as number : undefined,
+  };
+}
+
+function isTokenExpired(creds: OAuthCredentials): boolean {
+  if (creds.expiresAt == null) return false;
+  return Date.now() >= creds.expiresAt - TOKEN_EXPIRY_BUFFER_MS;
+}
+
+async function refreshOAuthToken(refreshToken: string): Promise<OAuthCredentials | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 8000);
+  try {
+    const resp = await fetch(OAUTH_TOKEN_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+        client_id: OAUTH_CLIENT_ID,
+      }),
+      signal: controller.signal,
+    });
+    if (!resp.ok) return null;
+    const body = (await resp.json()) as Record<string, unknown>;
+    const accessToken = body["access_token"];
+    if (typeof accessToken !== "string" || accessToken.length === 0) return null;
+    const expiresIn = typeof body["expires_in"] === "number" ? body["expires_in"] as number : undefined;
+    return {
+      accessToken,
+      refreshToken: typeof body["refresh_token"] === "string" ? body["refresh_token"] as string : refreshToken,
+      expiresAt: expiresIn ? Date.now() + expiresIn * 1000 : undefined,
+    };
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function persistRefreshedCredentials(creds: OAuthCredentials): Promise<void> {
+  if (process.platform === "darwin") {
+    try {
+      const { stdout } = await execFileAsync("security", [
+        "find-generic-password", "-s", "Claude Code-credentials", "-w",
+      ], { timeout: 3000 });
+      const parsed = JSON.parse(stdout.trim()) as Record<string, unknown>;
+      const oauth = (parsed["claudeAiOauth"] ?? {}) as Record<string, unknown>;
+      oauth["accessToken"] = creds.accessToken;
+      if (creds.refreshToken) oauth["refreshToken"] = creds.refreshToken;
+      if (creds.expiresAt) oauth["expiresAt"] = creds.expiresAt;
+      parsed["claudeAiOauth"] = oauth;
+      const updated = JSON.stringify(parsed);
+      await execFileAsync("security", [
+        "add-generic-password", "-U", "-s", "Claude Code-credentials", "-w", updated, "-a", os.userInfo().username,
+      ], { timeout: 3000 });
+    } catch {
+      // Best-effort — CLI fallback still works
+    }
+  }
+
+  const configDir = claudeConfigDir();
+  for (const filename of [".credentials.json", "credentials.json"]) {
+    const filePath = path.join(configDir, filename);
+    try {
+      const raw = await fs.readFile(filePath, "utf8");
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      const oauth = (parsed["claudeAiOauth"] ?? {}) as Record<string, unknown>;
+      oauth["accessToken"] = creds.accessToken;
+      if (creds.refreshToken) oauth["refreshToken"] = creds.refreshToken;
+      if (creds.expiresAt) oauth["expiresAt"] = creds.expiresAt;
+      parsed["claudeAiOauth"] = oauth;
+      await fs.writeFile(filePath, JSON.stringify(parsed, null, 2), "utf8");
+      return;
+    } catch {
+      // continue
+    }
+  }
+}
+
+async function readLocalClaudeCredentials(): Promise<OAuthCredentials | null> {
   const configDir = claudeConfigDir();
   for (const filename of [".credentials.json", "credentials.json"]) {
     try {
       const raw = await fs.readFile(path.join(configDir, filename), "utf8");
       const parsed = JSON.parse(raw) as Record<string, unknown>;
-      const oauth = parsed["claudeAiOauth"] as Record<string, unknown> | undefined;
-      const token = oauth?.["accessToken"];
-      if (typeof token === "string" && token.length > 0) return token;
+      const creds = extractOAuthCredentials(parsed);
+      if (creds) return creds;
     } catch {
       // continue
     }
@@ -203,11 +298,27 @@ async function readLocalClaudeToken(): Promise<string | null> {
         "-w",
       ], { timeout: 3000 });
       const parsed = JSON.parse(stdout.trim()) as Record<string, unknown>;
-      const oauth = parsed["claudeAiOauth"] as Record<string, unknown> | undefined;
-      const token = oauth?.["accessToken"];
-      if (typeof token === "string" && token.length > 0) return token;
+      const creds = extractOAuthCredentials(parsed);
+      if (creds) return creds;
     } catch {
       // continue
+    }
+  }
+
+  return null;
+}
+
+async function resolveValidToken(): Promise<string | null> {
+  const creds = await readLocalClaudeCredentials();
+  if (!creds) return null;
+
+  if (!isTokenExpired(creds)) return creds.accessToken;
+
+  if (creds.refreshToken) {
+    const refreshed = await refreshOAuthToken(creds.refreshToken);
+    if (refreshed) {
+      await persistRefreshedCredentials(refreshed);
+      return refreshed.accessToken;
     }
   }
 
@@ -374,14 +485,6 @@ async function fetchClaudeCliQuota(timeoutMs = 12_000): Promise<QuotaWindow[]> {
 // Core fetch logic
 // ---------------------------------------------------------------------------
 
-async function resolveToken(ctx: PluginContext): Promise<string | null> {
-  const config = (await ctx.config.get()) as PluginConfig;
-  if (config.claudeOauthToken && config.claudeOauthToken.trim().length > 0) {
-    return config.claudeOauthToken.trim();
-  }
-  return readLocalClaudeToken();
-}
-
 async function pollAndStore(ctx: PluginContext): Promise<ProviderSnapshot> {
   const config = (await ctx.config.get()) as PluginConfig;
   const enabledProviders = config.providers ?? DEFAULT_CONFIG.providers;
@@ -401,7 +504,7 @@ async function pollAndStore(ctx: PluginContext): Promise<ProviderSnapshot> {
 
   let snapshot: ProviderSnapshot;
   try {
-    const token = await resolveToken(ctx);
+    const token = await resolveValidToken();
     let windows: QuotaWindow[];
     let source: string;
 


### PR DESCRIPTION
## Summary

- Removed the `claudeOauthToken` plugin setting — no more manual token config
- Auto-detects OAuth credentials from `~/.claude` and macOS Keychain
- Adds automatic token refresh via `platform.claude.com/v1/oauth/token` when the access token expires
- Persists refreshed tokens back to credential store (Keychain + file)
- Falls back to CLI method if both OAuth and refresh fail

## Why

The plugin was exposing a manual OAuth token setting that had no reason to exist. Paperclip agents run on the same machine as Claude — they share the same credentials. When the access token expired, users got a confusing error telling them to update the token in plugin settings.

## Test plan

- [ ] Verify plugin starts and fetches usage without any manual token configured
- [ ] Verify the settings page no longer shows a token input field
- [ ] Verify expired token triggers auto-refresh (can test by manually setting a past `expiresAt`)
- [ ] Verify CLI fallback still works when OAuth is unavailable