### PR TITLE
fix(ui): refresh data after action so UI updates immediately

### DIFF
--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -386,7 +386,7 @@ function UsageBar({ window: w }: { window: QuotaWindow }) {
 // Refresh hook — shared across widget + page
 // ---------------------------------------------------------------------------
 
-function useRefresh() {
+function useRefresh(...dataRefreshers: Array<() => void>) {
   const refresh = usePluginAction("refresh");
   const [refreshing, setRefreshing] = useState(false);
   const [didRefresh, setDidRefresh] = useState(false);
@@ -396,6 +396,7 @@ function useRefresh() {
     setDidRefresh(false);
     try {
       await refresh({});
+      for (const r of dataRefreshers) r();
       setDidRefresh(true);
       setTimeout(() => setDidRefresh(false), 2500);
     } finally {
@@ -411,11 +412,11 @@ function useRefresh() {
 // ---------------------------------------------------------------------------
 
 export function AgentUsageDashboardWidget(_props: PluginWidgetProps) {
-  const { data: snapshot, loading } = usePluginData<ProviderSnapshot | null>(
+  const { data: snapshot, loading, refresh: refreshSnapshot } = usePluginData<ProviderSnapshot | null>(
     "latest-quota",
     {}
   );
-  const { refreshing, didRefresh, handleRefresh } = useRefresh();
+  const { refreshing, didRefresh, handleRefresh } = useRefresh(refreshSnapshot);
 
   if (loading) {
     return (
@@ -500,15 +501,15 @@ export function AgentUsageDashboardWidget(_props: PluginWidgetProps) {
 // ---------------------------------------------------------------------------
 
 export function AgentUsagePage(_props: PluginPageProps) {
-  const { data: snapshot, loading } = usePluginData<ProviderSnapshot | null>(
+  const { data: snapshot, loading, refresh: refreshSnapshot } = usePluginData<ProviderSnapshot | null>(
     "latest-quota",
     {}
   );
-  const { data: history } = usePluginData<UsageHistoryEntry[]>(
+  const { data: history, refresh: refreshHistory } = usePluginData<UsageHistoryEntry[]>(
     "usage-history",
     {}
   );
-  const { refreshing, didRefresh, handleRefresh } = useRefresh();
+  const { refreshing, didRefresh, handleRefresh } = useRefresh(refreshSnapshot, refreshHistory);
 
   return (
     <div style={base.pagePadding}>


### PR DESCRIPTION
## Summary

- The refresh/update button called the backend action (which stores new data) but never triggered `usePluginData` to re-fetch, leaving stale values in the UI until a full page reload
- `useRefresh` now accepts data-hook refresh callbacks and invokes them after the action succeeds
- Both the dashboard widget (`latest-quota`) and the full page (`latest-quota` + `usage-history`) now pass their refresh functions through

## Test plan

- [ ] Click the refresh button on the dashboard widget — usage bars should update immediately with fresh data
- [ ] Click the refresh button on the full Agent Usage page — both the current quota and the history table should update without a page reload
- [ ] Verify the "Just updated" label still appears after refresh
- [ ] Verify the loading/error states still work correctly

Fixes LAC-1847