### PR TITLE
fix: gracefully handle no-network errors [LAC-1878]

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -362,11 +362,29 @@ async function fetchClaudeCliQuota(timeoutMs = 12_000): Promise<QuotaWindow[]> {
     output = `${stdout}${stderr}`;
     const cleaned = cleanTerminalText(output);
     if (!cleaned.toLowerCase().includes("current session")) {
-      throw error instanceof Error ? error : new Error(String(error));
+      throw new Error(friendlyErrorMessage(error));
     }
   }
 
   return parseClaudeCliUsageText(output);
+}
+
+// ---------------------------------------------------------------------------
+// Error normalisation — strip leaked commands & detect network failures
+// ---------------------------------------------------------------------------
+
+function friendlyErrorMessage(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+
+  if (/ECONNREFUSED|ENETUNREACH|EAI_AGAIN|ENOTFOUND|EHOSTUNREACH|ETIMEDOUT|fetch failed|network/i.test(msg)) {
+    return "Network unavailable — check your internet connection and try again.";
+  }
+
+  if (/^Command failed:/i.test(msg)) {
+    return "Claude CLI command failed — ensure Claude is installed and your network is available.";
+  }
+
+  return msg;
 }
 
 // ---------------------------------------------------------------------------
@@ -417,7 +435,7 @@ async function pollAndStore(ctx: PluginContext): Promise<ProviderSnapshot> {
       fetchedAt: new Date().toISOString(),
     };
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = friendlyErrorMessage(err);
     snapshot = {
       provider: "claude",
       source: null,


### PR DESCRIPTION
## Summary
- When offline, `fetchClaudeCliQuota` threw the raw `Command failed: sh -c (sleep 2; printf '/usage\r'; ...) | script -q /dev/null claude --tools ""` error, leaking internal implementation details to the UI and logs.
- Added `friendlyErrorMessage()` that detects network errors (ECONNREFUSED, ENETUNREACH, etc.) and `Command failed:` patterns, replacing them with clean user-facing messages.
- Applied at both the CLI fallback throw site and the top-level `pollAndStore` catch, so all error paths are covered.

## Test plan
- [ ] Disable network and trigger a usage poll — should show "Network unavailable — check your internet connection and try again." instead of the raw shell command
- [ ] Verify normal online polling still works
- [ ] Confirm typecheck and build pass (verified locally)