### PR TITLE
fix: restore ESC byte in stripAnsi regex [LAC-2003]

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -231,8 +231,8 @@ function stripBackspaces(text: string): string {
 
 function stripAnsi(text: string): string {
   return text
-    .replace(/\][^]*(?:|\\)/g, "")
-    .replace(/(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, "");
+    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, "")
+    .replace(/\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, "");
 }
 
 function cleanTerminalText(text: string): string {


### PR DESCRIPTION
## Summary
- Fixes [LAC-2003](https://paperclipai.com/LAC/issues/LAC-2003). The two regexes in `stripAnsi` (`src/worker.ts:232-236`) were missing the `\x1b` ESC prefix (and the OSC variant was missing the `\x07` BEL alternative).
- Effect of the bug: the first regex matched any `]` followed by any chars to end-of-input; the second silently deleted any uppercase letter, `@`, backslash, `]`, `^`, or `_`. `"Current session [stuff] used 50% remaining"` became `"urrent session tuff"`, which broke the `claude /usage` CLI fallback path end-to-end (label detection and the catch-block guard both failed).
- Fix is the inline regex correction suggested in the issue — no new dependency.

## Test plan
- [x] `node -e` smoke check over the example input asserts the cleaned text still contains the literal substring `Current session` and is unchanged when no ANSI is present.
- [x] Same smoke check confirms a real ANSI string (`\x1b[1mCurrent session\x1b[0m \x1b]0;title\x07[stuff]…`) gets escapes stripped while content is preserved.
- [x] `npm run typecheck` passes.
- [ ] End-to-end verify the CLI fallback path returns a non-empty `windows[]` (simulate by deleting `~/.claude/.credentials.json` and watching the worker pick the fallback branch) — recommend QA covers this.

## API/Migration notes
- No API surface change. No migrations.