### PR TITLE
fix: history race, stale-threshold, useRefresh leaks, keyframe SSR [LAC-2005]

### DIFF
--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type CSSProperties } from "react";
+import { useEffect, useInsertionEffect, useRef, useState, type CSSProperties } from "react";
 import {
   usePluginAction,
   usePluginData,
@@ -88,12 +88,18 @@ function formatAge(isoDate: string): string {
   return `${hours}h ago`;
 }
 
-// Inject spin keyframe once at module load for the refresh icon animation
-if (typeof document !== "undefined" && !document.getElementById("__au_kf")) {
-  const s = document.createElement("style");
-  s.id = "__au_kf";
-  s.textContent = "@keyframes au_spin { from { transform: rotate(0deg) } to { transform: rotate(360deg) } }";
-  document.head.appendChild(s);
+// Injected on first mount of a component that uses the spin animation. Keeps
+// module evaluation side-effect free so importing this file in SSR/test
+// environments doesn't mutate `document`.
+function useSpinKeyframe() {
+  useInsertionEffect(() => {
+    if (typeof document === "undefined") return;
+    if (document.getElementById("__au_kf")) return;
+    const s = document.createElement("style");
+    s.id = "__au_kf";
+    s.textContent = "@keyframes au_spin { from { transform: rotate(0deg) } to { transform: rotate(360deg) } }";
+    document.head.appendChild(s);
+  }, []);
 }
 
 // ---------------------------------------------------------------------------
@@ -216,6 +222,7 @@ function btnIcon(extra?: CSSProperties): CSSProperties {
 }
 
 function RefreshIcon({ size = 13, spin = false }: { size?: number; spin?: boolean }) {
+  useSpinKeyframe();
   return (
     <svg
       width={size}
@@ -390,21 +397,70 @@ function useRefresh(...dataRefreshers: Array<() => void>) {
   const refresh = usePluginAction("refresh");
   const [refreshing, setRefreshing] = useState(false);
   const [didRefresh, setDidRefresh] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const didRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (didRefreshTimerRef.current != null) {
+        clearTimeout(didRefreshTimerRef.current);
+        didRefreshTimerRef.current = null;
+      }
+    };
+  }, []);
 
   const handleRefresh = async () => {
+    if (didRefreshTimerRef.current != null) {
+      clearTimeout(didRefreshTimerRef.current);
+      didRefreshTimerRef.current = null;
+    }
     setRefreshing(true);
     setDidRefresh(false);
+    setError(null);
     try {
       await refresh({});
+      if (!mountedRef.current) return;
       for (const r of dataRefreshers) r();
       setDidRefresh(true);
-      setTimeout(() => setDidRefresh(false), 2500);
+      didRefreshTimerRef.current = setTimeout(() => {
+        didRefreshTimerRef.current = null;
+        setDidRefresh(false);
+      }, 2500);
+    } catch (err) {
+      if (!mountedRef.current) return;
+      setError(err instanceof Error ? err.message : String(err));
     } finally {
-      setRefreshing(false);
+      if (mountedRef.current) setRefreshing(false);
     }
   };
 
-  return { refreshing, didRefresh, handleRefresh };
+  return { refreshing, didRefresh, error, handleRefresh };
+}
+
+// ---------------------------------------------------------------------------
+// Inline refresh-error banner — surfaces failures from useRefresh
+// ---------------------------------------------------------------------------
+
+function RefreshErrorBanner({ message }: { message: string }) {
+  return (
+    <div
+      role="alert"
+      style={{
+        padding: "8px 10px",
+        marginBottom: "8px",
+        borderRadius: "var(--radius, 0)",
+        border: `1px solid ${t.destructive}`,
+        background: t.card,
+        color: t.destructive,
+        fontSize: "12px",
+      }}
+    >
+      Refresh failed: {message}
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -416,7 +472,7 @@ export function AgentUsageDashboardWidget(_props: PluginWidgetProps) {
     "latest-quota",
     {}
   );
-  const { refreshing, didRefresh, handleRefresh } = useRefresh(refreshSnapshot);
+  const { refreshing, didRefresh, error: refreshError, handleRefresh } = useRefresh(refreshSnapshot);
 
   if (loading) {
     return (
@@ -429,6 +485,7 @@ export function AgentUsageDashboardWidget(_props: PluginWidgetProps) {
   if (!snapshot) {
     return (
       <div style={base.container}>
+        {refreshError && <RefreshErrorBanner message={refreshError} />}
         <div
           style={{
             padding: "12px",
@@ -465,6 +522,7 @@ export function AgentUsageDashboardWidget(_props: PluginWidgetProps) {
 
   return (
     <div style={base.container}>
+      {refreshError && <RefreshErrorBanner message={refreshError} />}
       <div
         style={{
           display: "flex",
@@ -509,7 +567,7 @@ export function AgentUsagePage(_props: PluginPageProps) {
     "usage-history",
     {}
   );
-  const { refreshing, didRefresh, handleRefresh } = useRefresh(refreshSnapshot, refreshHistory);
+  const { refreshing, didRefresh, error: refreshError, handleRefresh } = useRefresh(refreshSnapshot, refreshHistory);
 
   return (
     <div style={base.pagePadding}>
@@ -525,6 +583,8 @@ export function AgentUsagePage(_props: PluginPageProps) {
           <RefreshIcon spin={refreshing} size={15} />
         </button>
       </div>
+
+      {refreshError && <RefreshErrorBanner message={refreshError} />}
 
       {loading && <LoadingSkeleton bars={3} />}
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -231,8 +231,8 @@ function stripBackspaces(text: string): string {
 
 function stripAnsi(text: string): string {
   return text
-    .replace(/\][^]*(?:|\\)/g, "")
-    .replace(/(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, "");
+    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, "")
+    .replace(/\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, "");
 }
 
 function cleanTerminalText(text: string): string {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -232,7 +232,7 @@ function stripBackspaces(text: string): string {
 function stripAnsi(text: string): string {
   return text
     .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, "")
-    .replace(/\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, "");
+    .replace(/\x1b(?:\[[0-?]*[ -/]*[@-~]|[@-Z\\-_])/g, "");
 }
 
 function cleanTerminalText(text: string): string {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -391,7 +391,20 @@ function friendlyErrorMessage(err: unknown): string {
 // Core fetch logic
 // ---------------------------------------------------------------------------
 
-async function pollAndStore(ctx: PluginContext): Promise<ProviderSnapshot> {
+// Serialize pollAndStore so the scheduled job, the `refresh` action, and the
+// tool-driven stale-snapshot fallback never read-modify-write `usage-history`
+// concurrently. Each caller queues onto a shared promise chain and runs its
+// own poll + append after the previous call finishes, so no history entries
+// are lost. Failures don't poison the chain.
+let pollChain: Promise<unknown> = Promise.resolve();
+
+function pollAndStore(ctx: PluginContext): Promise<ProviderSnapshot> {
+  const next = pollChain.then(() => runPollAndStore(ctx));
+  pollChain = next.catch(() => undefined);
+  return next;
+}
+
+async function runPollAndStore(ctx: PluginContext): Promise<ProviderSnapshot> {
   const config = (await ctx.config.get()) as PluginConfig;
   const enabledProviders = config.providers ?? DEFAULT_CONFIG.providers;
 
@@ -484,6 +497,15 @@ function formatTimeDelta(isoDate: string): string {
   const hours = Math.round(minutes / 60);
   if (hours < 24) return `${hours}h`;
   return `${Math.round(hours / 24)}d`;
+}
+
+// Tool handlers treat a snapshot as stale when it's older than the configured
+// poll interval. Floored at 5 minutes so an aggressive `pollIntervalMinutes: 1`
+// doesn't burn CLI invocations on every tool call.
+async function staleThresholdMs(ctx: PluginContext): Promise<number> {
+  const config = (await ctx.config.get()) as PluginConfig;
+  const intervalMinutes = config.pollIntervalMinutes ?? DEFAULT_CONFIG.pollIntervalMinutes;
+  return Math.max(intervalMinutes, 5) * 60_000;
 }
 
 function buildSummary(snapshot: ProviderSnapshot): string {
@@ -588,9 +610,10 @@ const plugin: PaperclipPlugin = definePlugin({
           stateKey: STATE_KEYS.latestQuota,
         })) as ProviderSnapshot | null;
 
+        const thresholdMs = await staleThresholdMs(ctx);
         if (
           !snapshot ||
-          Date.now() - new Date(snapshot.fetchedAt).getTime() > 20 * 60 * 1000
+          Date.now() - new Date(snapshot.fetchedAt).getTime() > thresholdMs
         ) {
           snapshot = await pollAndStore(ctx);
         }
@@ -616,9 +639,10 @@ const plugin: PaperclipPlugin = definePlugin({
           stateKey: STATE_KEYS.latestQuota,
         })) as ProviderSnapshot | null;
 
+        const thresholdMs = await staleThresholdMs(ctx);
         if (
           !snapshot ||
-          Date.now() - new Date(snapshot.fetchedAt).getTime() > 20 * 60 * 1000
+          Date.now() - new Date(snapshot.fetchedAt).getTime() > thresholdMs
         ) {
           snapshot = await pollAndStore(ctx);
         }


### PR DESCRIPTION
Paperclip issue: [LAC-2005](https://paperclip.ing/LAC/issues/LAC-2005)

## Summary

Four lower-severity cleanup items from the LAC-1997 review, bundled per the issue's "group if trivial" guidance.

1. **History race** (`src/worker.ts`) — `pollAndStore` could read `usage-history`, prepend, and write back concurrently with itself, losing entries on the second `set`. Replace with a module-scope promise chain so calls serialize; failures are swallowed so they don't poison the chain. Each call still runs its own poll + append, so two parallel callers produce two history entries.

2. **Stale-snapshot threshold** (`src/worker.ts`) — tool handlers were hard-coded to 20 minutes regardless of `pollIntervalMinutes`. Derive the threshold from config with a 5-minute floor so aggressive intervals don't trigger a CLI poll on every tool call and conservative intervals stay aligned.

3. **`useRefresh` leaks** (`src/ui/index.tsx`) — added a `catch` that surfaces failures via a new inline `RefreshErrorBanner`; tracked the success-flash `setTimeout` in a `useRef` and clear it on unmount and on the next click; gated `setState` after unmount with a mounted ref so rapid-click + unmount no longer warns.

4. **Module-load DOM mutation** (`src/ui/index.tsx`) — moved the `<style id="__au_kf">` keyframe injection from module evaluation into a `useInsertionEffect` called from `RefreshIcon`. Importing the file in SSR/test environments no longer mutates `document.head`.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [ ] Manual: trigger refresh while worker is unreachable → inline banner appears.
- [ ] Manual: unmount the widget mid-refresh → no React state-on-unmount warning in dev.
- [ ] Manual: no `style#__au_kf` in `document.head` until widget/page mounts.
- [ ] Manual: fire `pollAndStore` twice in parallel → `usage-history` contains both entries.
- [ ] Manual: with `pollIntervalMinutes: 5`, `get-usage` returns a fresh result within 5 minutes of a tick.