### PR TITLE
fix: stop stripping spaces in cleanTerminalText so guards match [LAC-2023]

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -236,9 +236,7 @@ function stripAnsi(text: string): string {
 }
 
 function cleanTerminalText(text: string): string {
-  return stripAnsi(stripBackspaces(text))
-    .replace(/ /g, "")
-    .replace(/\r/g, "\n");
+  return stripAnsi(stripBackspaces(text)).replace(/\r/g, "\n");
 }
 
 function normalizeForLabelSearch(text: string): string {


### PR DESCRIPTION
## Summary

`cleanTerminalText` in `src/worker.ts` unconditionally stripped every space via `.replace(/ /g, "")`, but two downstream guards still matched against space-bearing literals — so the guards never fired and broke the CLI fallback path.

- **`trimToLatestUsagePanel`** (line 255) checks `tailLower.includes("current session")` / `"loading usage"` against text returned by `cleanTerminalText`. After the space-strip those substrings could never appear, so the function bailed and the usage panel was never trimmed to the latest section.
- **Catch-block fallback in `fetchClaudeCliQuota`** (line 364) guards on `cleaned.toLowerCase().includes("current session")` to decide whether partial stdout still contained usable usage data before re-throwing a friendly error. The guard always failed → the catch always re-threw, even when valid usage data was present.

Per the issue's recommended fix (Option 1), this PR drops the space-strip from `cleanTerminalText`. Label detection (`isQuotaLabel`, `canonicalQuotaLabel`) already uses `normalizeForLabelSearch`, which strips all non-alphanumerics, so it remains space-tolerant. `percentFromLine` uses `\s*%` for its own tolerance, and the "remaining/left/available" hint still matches the original spaced text.

Closes LAC-2023.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] Reproduction script: `"\x1b[1mCurrent session\x1b[0m used 50%"` → after fix `cleanTerminalText` yields `"Current session used 50%"`; `.includes("current session")` returns `true`.
- [ ] Manual: run `claude /usage` capture, verify `parseClaudeCliUsageText` returns parsed `windows[]` and that catch-block fallback no longer re-throws when stdout contains a usage panel.