### PR TITLE
fix: increase CLI quota timing margins and add retry [LAC-2397]

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -339,8 +339,8 @@ function quoteForShell(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
-async function fetchClaudeCliQuota(timeoutMs = 12_000): Promise<QuotaWindow[]> {
-  const feed = "(sleep 2; printf '/usage\\r'; sleep 6; printf '\\033'; sleep 1; printf '\\003')";
+async function runClaudeCliCommand(timeoutMs: number): Promise<QuotaWindow[]> {
+  const feed = "(sleep 3; printf '/usage\\r'; sleep 8; printf '\\033'; sleep 1; printf '\\003')";
   const claudeCommand = "claude --tools \"\"";
   const command = process.platform === "darwin"
     ? `${feed} | script -q /dev/null ${claudeCommand}`
@@ -365,6 +365,14 @@ async function fetchClaudeCliQuota(timeoutMs = 12_000): Promise<QuotaWindow[]> {
   }
 
   return parseClaudeCliUsageText(output);
+}
+
+async function fetchClaudeCliQuota(timeoutMs = 20_000): Promise<QuotaWindow[]> {
+  try {
+    return await runClaudeCliCommand(timeoutMs);
+  } catch {
+    return await runClaudeCliCommand(timeoutMs);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -370,7 +370,8 @@ async function runClaudeCliCommand(timeoutMs: number): Promise<QuotaWindow[]> {
 async function fetchClaudeCliQuota(timeoutMs = 20_000): Promise<QuotaWindow[]> {
   try {
     return await runClaudeCliCommand(timeoutMs);
-  } catch {
+  } catch (error) {
+    console.warn("CLI quota fetch failed on first attempt, retrying…", error);
     return await runClaudeCliCommand(timeoutMs);
   }
 }


### PR DESCRIPTION
## Summary
- Increase initial sleep from 2s to 3s so the Claude CLI has more time to start up before `/usage` is sent
- Increase the read delay from 6s to 8s to allow the usage panel to fully render
- Increase default timeout from 12s to 20s (12s of sleeps + 8s of headroom, up from 3s)
- Add a single automatic retry — if the first CLI invocation fails, try once more before propagating the error

Fixes the intermittent `Command failed: sh -c ...` errors reported in LAC-2397.

## Test plan
- [ ] All existing unit tests pass (`npm test` / `npx vitest run`)
- [ ] Manual verification: the CLI fallback path succeeds on machines where it previously failed intermittently
- [ ] Confirm no regression when the OAuth token path is available (retry logic only applies to CLI fallback)