### PR TITLE
feat: show signed-in account email in usage component [LAC-3028]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Signed-in account email shown in the dashboard widget, usage page, settings page, and agent usage summary, so multi-account users can tell which account the quota belongs to (LAC-3028).
+
 - Centered README hero, logo (pink quota-bars on rounded square), 5 modern badges.
 - `.github/` community files: FUNDING, dependabot, ISSUE_TEMPLATE, PR template, SECURITY, CONTRIBUTING.
 - CI typecheck + build workflow on Node 18/20/22.

--- a/src/parsing.test.ts
+++ b/src/parsing.test.ts
@@ -13,6 +13,7 @@ import assert from "node:assert/strict";
 import {
   canonicalQuotaLabel,
   cleanTerminalText,
+  extractAccountEmail,
   formatCurrency,
   formatTimeDelta,
   friendlyErrorMessage,
@@ -440,4 +441,35 @@ test("formatTimeDelta: minute / hour / day buckets", () => {
   assert.equal(formatTimeDelta("2026-05-21T12:30:00Z", now), "30m");
   assert.equal(formatTimeDelta("2026-05-21T15:00:00Z", now), "3h");
   assert.equal(formatTimeDelta("2026-05-24T12:00:00Z", now), "3d");
+});
+
+// ---------------------------------------------------------------------------
+// extractAccountEmail (LAC-3028)
+// ---------------------------------------------------------------------------
+
+test("extractAccountEmail: reads oauthAccount.emailAddress", () => {
+  assert.equal(
+    extractAccountEmail({ oauthAccount: { emailAddress: "user@example.com" } }),
+    "user@example.com",
+  );
+});
+
+test("extractAccountEmail: trims surrounding whitespace", () => {
+  assert.equal(
+    extractAccountEmail({ oauthAccount: { emailAddress: "  user@example.com  " } }),
+    "user@example.com",
+  );
+});
+
+test("extractAccountEmail: null for missing, empty, or malformed shapes", () => {
+  assert.equal(extractAccountEmail(null), null);
+  assert.equal(extractAccountEmail(undefined), null);
+  assert.equal(extractAccountEmail("string"), null);
+  assert.equal(extractAccountEmail({}), null);
+  assert.equal(extractAccountEmail({ oauthAccount: null }), null);
+  assert.equal(extractAccountEmail({ oauthAccount: "not-an-object" }), null);
+  assert.equal(extractAccountEmail({ oauthAccount: {} }), null);
+  assert.equal(extractAccountEmail({ oauthAccount: { emailAddress: "" } }), null);
+  assert.equal(extractAccountEmail({ oauthAccount: { emailAddress: "   " } }), null);
+  assert.equal(extractAccountEmail({ oauthAccount: { emailAddress: 42 } }), null);
 });

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -108,6 +108,17 @@ export function parseAnthropicResponse(body: AnthropicUsageResponse): QuotaWindo
   return windows;
 }
 
+// Extracts the signed-in account email from Claude Code's main config
+// (`.claude.json`), whose `oauthAccount.emailAddress` identifies the account.
+export function extractAccountEmail(parsed: unknown): string | null {
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const account = (parsed as Record<string, unknown>)["oauthAccount"];
+  if (typeof account !== "object" || account === null) return null;
+  const email = (account as Record<string, unknown>)["emailAddress"];
+  if (typeof email === "string" && email.trim().length > 0) return email.trim();
+  return null;
+}
+
 export function stripBackspaces(text: string): string {
   let out = "";
   for (const char of text) {

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -22,6 +22,8 @@ interface QuotaWindow {
 interface ProviderSnapshot {
   provider: string;
   source: string | null;
+  // Optional: snapshots stored before the account field existed lack it.
+  account?: string | null;
   ok: boolean;
   error: string | null;
   windows: QuotaWindow[];
@@ -547,6 +549,11 @@ export function AgentUsageDashboardWidget(_props: PluginWidgetProps) {
           </button>
         </div>
       </div>
+      {snapshot.account && (
+        <div style={{ ...base.meta, marginTop: 0, marginBottom: "10px" }}>
+          Signed in as {snapshot.account}
+        </div>
+      )}
       {snapshot.windows.map((w, i) => (
         <UsageBar key={i} window={w} />
       ))}
@@ -630,6 +637,7 @@ export function AgentUsagePage(_props: PluginPageProps) {
               Current Quota — {snapshot.provider}
             </h3>
             <span style={base.metaInline}>
+              {snapshot.account && <>{snapshot.account} · </>}
               via {snapshot.source} ·{" "}
               {didRefresh ? (
                 <span style={{ color: t.ok }}>just updated</span>
@@ -810,6 +818,9 @@ export function AgentUsageSettingsPage(_props: PluginSettingsPageProps) {
         </Row>
         <Row label="Provider">
           <span style={{ color: t.fg }}>{snapshot?.provider ?? "—"}</span>
+        </Row>
+        <Row label="Account">
+          <span style={{ color: t.fg }}>{snapshot?.account ?? "—"}</span>
         </Row>
         <Row label="Token source">
           <span style={{ color: t.fg }}>{snapshot?.source ?? "—"}</span>

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -32,6 +32,7 @@ interface QuotaWindow {
 interface ProviderSnapshot {
   provider: string;
   source: string | null;
+  account: string | null;
   ok: boolean;
   error: string | null;
   windows: QuotaWindow[];
@@ -211,6 +212,38 @@ async function readLocalClaudeToken(): Promise<string | null> {
     }
   }
 
+  return null;
+}
+
+function extractAccountEmail(parsed: unknown): string | null {
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const account = (parsed as Record<string, unknown>)["oauthAccount"];
+  if (typeof account !== "object" || account === null) return null;
+  const email = (account as Record<string, unknown>)["emailAddress"];
+  if (typeof email === "string" && email.trim().length > 0) return email.trim();
+  return null;
+}
+
+// The signed-in account lives in Claude Code's main config (`.claude.json`),
+// which sits inside CLAUDE_CONFIG_DIR when that's set and at ~/.claude.json
+// otherwise — a different file from the credentials read above.
+async function readLocalClaudeAccount(): Promise<string | null> {
+  const candidates: string[] = [];
+  const fromEnv = process.env.CLAUDE_CONFIG_DIR;
+  if (typeof fromEnv === "string" && fromEnv.trim().length > 0) {
+    candidates.push(path.join(fromEnv.trim(), ".claude.json"));
+  }
+  candidates.push(path.join(os.homedir(), ".claude.json"));
+
+  for (const file of candidates) {
+    try {
+      const raw = await fs.readFile(file, "utf8");
+      const email = extractAccountEmail(JSON.parse(raw));
+      if (email) return email;
+    } catch {
+      // continue
+    }
+  }
   return null;
 }
 
@@ -403,11 +436,13 @@ function pollAndStore(ctx: PluginContext): Promise<ProviderSnapshot> {
 async function runPollAndStore(ctx: PluginContext): Promise<ProviderSnapshot> {
   const config = (await ctx.config.get()) as PluginConfig;
   const enabledProviders = config.providers ?? DEFAULT_CONFIG.providers;
+  const account = await readLocalClaudeAccount();
 
   if (!enabledProviders.includes("claude")) {
     const snapshot: ProviderSnapshot = {
       provider: "claude",
       source: null,
+      account,
       ok: false,
       error: "Provider 'claude' is not enabled in config",
       windows: [],
@@ -438,6 +473,7 @@ async function runPollAndStore(ctx: PluginContext): Promise<ProviderSnapshot> {
     snapshot = {
       provider: "claude",
       source,
+      account,
       ok: true,
       error: null,
       windows,
@@ -448,6 +484,7 @@ async function runPollAndStore(ctx: PluginContext): Promise<ProviderSnapshot> {
     snapshot = {
       provider: "claude",
       source: null,
+      account,
       ok: false,
       error: message,
       windows: [],
@@ -508,7 +545,8 @@ function buildSummary(snapshot: ProviderSnapshot): string {
   if (!snapshot.ok) return `Claude usage unavailable: ${snapshot.error}`;
   if (snapshot.windows.length === 0) return "No usage data available.";
 
-  const lines: string[] = [`Claude usage (as of ${snapshot.fetchedAt}):`];
+  const accountSuffix = snapshot.account ? ` for ${snapshot.account}` : "";
+  const lines: string[] = [`Claude usage${accountSuffix} (as of ${snapshot.fetchedAt}):`];
   for (const w of snapshot.windows) {
     let line = `  ${w.label}: `;
     if (w.usedPercent != null) {


### PR DESCRIPTION
## Summary
- Adds `account` (signed-in email) to the usage snapshot, read from Claude Code's local config (`oauthAccount.emailAddress` in `.claude.json`, honoring `CLAUDE_CONFIG_DIR`).
- Displays it in the dashboard widget ("Signed in as …"), the full usage page meta line, the settings page (new **Account** row), and the agent-facing `get_usage_summary` text.
- Field is optional in the UI types so snapshots stored before this change render unchanged.
- Pure extractor `extractAccountEmail` mirrored in `parsing.ts` with unit tests (valid, whitespace, and 10 malformed shapes).

Fixes LAC-3028 — multi-account users couldn't tell which account the displayed quota belonged to.

## Testing
- `npm run typecheck` clean
- `npm test` — 49/49 pass (3 new)
- `npm run build` succeeds
- Verified `~/.claude.json` on this machine has `oauthAccount.emailAddress` populated