### PR TITLE
fix: pin SDK version and auto-build dist on install

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "paperclip-plugin-agent-usage",
       "dependencies": {
-        "@paperclipai/plugin-sdk": "latest",
+        "@paperclipai/plugin-sdk": "2026.722.0",
       },
       "devDependencies": {
         "@lacymorrow/shipx": "^0.1.0",
@@ -81,9 +81,9 @@
 
     "@lacymorrow/shipx": ["@lacymorrow/shipx@0.1.0", "", { "dependencies": { "@clack/prompts": "^1.0.0", "picocolors": "^1.1.1" }, "bin": { "shipx": "dist/cli.js" } }, "sha512-x2wYyL5Fe/3Jxj8qaWqrhQ0HszwMVcsFdJ575UIHy1Uz07jkuPH7VduBtZoRXp7IC9sNJ0gY83e8UpX9iJ5yDw=="],
 
-    "@paperclipai/plugin-sdk": ["@paperclipai/plugin-sdk@2026.428.0", "", { "dependencies": { "@paperclipai/shared": "2026.428.0", "zod": "^3.24.2" }, "peerDependencies": { "react": ">=18" }, "bin": { "paperclip-plugin-dev-server": "dist/dev-cli.js" } }, "sha512-FcpV5zmSCz6Kkp+JfSmHNtcmN6NJyMxCv3ILwj1/yesRa4xP+mEmJrMnkXC9PLeVeIoEub7BlmVJ9UWzig2JKA=="],
+    "@paperclipai/plugin-sdk": ["@paperclipai/plugin-sdk@2026.722.0", "", { "dependencies": { "@paperclipai/shared": "2026.722.0", "zod": "^3.24.2" }, "peerDependencies": { "react": ">=18" }, "bin": { "paperclip-plugin-dev-server": "dist/dev-cli.js" } }, "sha512-2rMJCBo8ZAouuMsapdaY4/l+oHmrXKHW/k/HfPOLCxFng7+g04c5JhoFq+/ptGfNcW3kXzs34y7brviDCml06Q=="],
 
-    "@paperclipai/shared": ["@paperclipai/shared@2026.428.0", "", { "dependencies": { "zod": "^3.24.2" } }, "sha512-b4irrk/b+aGafkDgURVZJ/uGkyL1ryXy85RUv6cr1X+hg4581CejIiZ4QDMNxCGtRzfyKKXIecSDaq8Yqx4gKw=="],
+    "@paperclipai/shared": ["@paperclipai/shared@2026.722.0", "", { "dependencies": { "zod": "^3.24.2" } }, "sha512-JciI6EbtNwHSeoyN5ZkshwqpyfIluyO46JHp8I7pPCvpJ7Uv7MSZEBs3lKXdXLadFEN6qzfwNmf39xjIFC8isA=="],
 
     "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
-        "@paperclipai/plugin-sdk": "latest"
+        "@paperclipai/plugin-sdk": "2026.722.0"
       },
       "devDependencies": {
         "@lacymorrow/shipx": "^0.1.0",
@@ -526,12 +526,12 @@
       }
     },
     "node_modules/@paperclipai/plugin-sdk": {
-      "version": "2026.517.0",
-      "resolved": "https://registry.npmjs.org/@paperclipai/plugin-sdk/-/plugin-sdk-2026.517.0.tgz",
-      "integrity": "sha512-p8FlMUy5cds4fQjKoi9fD60XJWlnoLhBa+AsCPvVfilbulL9vpnAD0M8KBXJO+rEgmI/PZ9kHAiLuYVE1g0Now==",
+      "version": "2026.722.0",
+      "resolved": "https://registry.npmjs.org/@paperclipai/plugin-sdk/-/plugin-sdk-2026.722.0.tgz",
+      "integrity": "sha512-2rMJCBo8ZAouuMsapdaY4/l+oHmrXKHW/k/HfPOLCxFng7+g04c5JhoFq+/ptGfNcW3kXzs34y7brviDCml06Q==",
       "license": "MIT",
       "dependencies": {
-        "@paperclipai/shared": "2026.517.0",
+        "@paperclipai/shared": "2026.722.0",
         "zod": "^3.24.2"
       },
       "bin": {
@@ -547,9 +547,9 @@
       }
     },
     "node_modules/@paperclipai/shared": {
-      "version": "2026.517.0",
-      "resolved": "https://registry.npmjs.org/@paperclipai/shared/-/shared-2026.517.0.tgz",
-      "integrity": "sha512-wAaP+rkOmCVm5GZvjYAyUkm3MGa3J7BH3D8ftFt1802N7d4l8ARXNqvGq55wzTYYZRrIs4DRpZxxiSSD5PrSng==",
+      "version": "2026.722.0",
+      "resolved": "https://registry.npmjs.org/@paperclipai/shared/-/shared-2026.722.0.tgz",
+      "integrity": "sha512-JciI6EbtNwHSeoyN5ZkshwqpyfIluyO46JHp8I7pPCvpJ7Uv7MSZEBs3lKXdXLadFEN6qzfwNmf39xjIFC8isA==",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.24.2"

--- a/package.json
+++ b/package.json
@@ -26,12 +26,13 @@
     "typecheck": "tsc --noEmit",
     "test": "node --test --experimental-strip-types 'src/**/*.test.ts'",
     "dev": "node ./scripts/build.mjs --watch",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build",
     "release": "shipx",
     "release:beta": "shipx --beta"
   },
   "dependencies": {
-    "@paperclipai/plugin-sdk": "latest"
+    "@paperclipai/plugin-sdk": "2026.722.0"
   },
   "devDependencies": {
     "@lacymorrow/shipx": "^0.1.0",


### PR DESCRIPTION
## Summary

Installing this plugin from a git ref or local path (`isLocalPath: true`) currently fails or produces a broken install, for two related reasons:

- `@paperclipai/plugin-sdk` is pinned to `latest` in `package.json`/lockfiles. This makes installs non-reproducible — two installs on different days can silently resolve different SDK versions, and a breaking SDK release can brick existing installs with no way to pin back. Pinned to the current release, `2026.722.0`.
- There is no `prepare` script, so `dist/` is never built when installing from a git ref or local path (only `npm publish` triggers `prepublishOnly`). Consumers installing via `{ "packageName": "/path/to/paperclip-plugin-agent-usage", "isLocalPath: true }"` (documented in this repo's own README) get a plugin with no `dist/manifest.js` / `dist/worker.js`, which fails to load in Paperclip.

Both were found while debugging repeated install failures against a self-hosted Paperclip instance.

## How to test

```bash
rm -rf node_modules dist
npm install        # prepare script now builds dist/ automatically
npm run typecheck
npm run build
npm test
```

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run build` produces `dist/manifest.js` + `dist/worker.js`
- [ ] Updated the README if a public option or agent tool changed — n/a, no public option or tool changed
- [x] PR is focused (one logical change)