### PR TITLE
fix: correct toPercent units and de-duplicate worker.ts/parsing.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Install code blocks switched from `bash` to `http` fence (matches the pseudo-HTTP REST shape).
 - PR template + CONTRIBUTING aligned with actual `npm run typecheck` / `npm run build` workflow.
 - npm keywords expanded (paperclip-plugin, ai, ai-agent, agent, quota, usage, tracking, oauth).
+- `worker.ts` now imports its parsing/formatting helpers from `parsing.ts` instead of maintaining a second, drifting copy of each.
+
+### Fixed
+
+- `toPercent` was multiplying `utilization` by 100, assuming a 0..1 fraction. The Anthropic OAuth usage API actually returns it as a whole percentage already, so any real (non-zero) usage was clamping straight to 100%.
 
 ## [0.1.4] and earlier
 

--- a/src/parsing.test.ts
+++ b/src/parsing.test.ts
@@ -4,6 +4,12 @@
 //   LAC-2004 — toPercent reported 1% for 100%-utilized windows
 //   LAC-2005 — stripAnsi alternation order (CSI before single-char)
 //   LAC-2023 — cleanTerminalText was stripping spaces, breaking guards
+//   2026-08-03 — toPercent treated `utilization` as a 0..1 fraction and
+//     multiplied by 100. The real API returns it as a whole percentage
+//     already (confirmed against the same response's own `limits[].percent`
+//     field), so any real usage >=1% was clamping straight to 100%. This
+//     reverses LAC-2004's fix, which was chasing the opposite bug against
+//     the wrong assumption about the API's units.
 //
 // Run with: npm test
 
@@ -29,7 +35,7 @@ import {
 } from "./parsing.ts";
 
 // ---------------------------------------------------------------------------
-// toPercent — LAC-2004
+// toPercent
 // ---------------------------------------------------------------------------
 
 test("toPercent: returns null for nullish input", () => {
@@ -43,22 +49,27 @@ test("toPercent: returns null for non-finite input (NaN, Infinity)", () => {
   assert.equal(toPercent(Number.NEGATIVE_INFINITY), null);
 });
 
-test("toPercent: scales 0..1 fractions to 0..100", () => {
+test("toPercent: passes whole percentages through, rounding fractional ones", () => {
   assert.equal(toPercent(0), 0);
-  assert.equal(toPercent(0.5), 50);
-  assert.equal(toPercent(0.755), 76);
+  assert.equal(toPercent(50), 50);
+  assert.equal(toPercent(75.6), 76);
 });
 
-test("toPercent: 100% utilization reports 100 (regression: LAC-2004)", () => {
-  // The pre-fix code treated `utilization < 1` as a fraction and `>= 1` as
-  // already-percent, so utilization === 1.0 fell into the "already-percent"
-  // branch and became 1, not 100.
-  assert.equal(toPercent(1), 100);
-  assert.equal(toPercent(0.999), 100);
+test("toPercent: low utilization stays low (regression: 2026-08-03)", () => {
+  // A real low-usage account returned utilization: 1.0 (1%) and 31.0 (31%),
+  // corroborated by the same response's limits[].percent field. The
+  // pre-fix code multiplied by 100, reporting 100% and clamping the 31%
+  // case to 100% too — every non-trivial usage value read as "fully used."
+  assert.equal(toPercent(1), 1);
+  assert.equal(toPercent(31), 31);
+});
+
+test("toPercent: 100% utilization reports 100", () => {
+  assert.equal(toPercent(100), 100);
 });
 
 test("toPercent: clamps over-100 values to 100", () => {
-  assert.equal(toPercent(1.5), 100);
+  assert.equal(toPercent(150), 100);
   assert.equal(toPercent(99999), 100);
 });
 
@@ -294,7 +305,7 @@ test("parseClaudeCliUsageText: throws when no session window can be found", () =
 });
 
 // ---------------------------------------------------------------------------
-// parseAnthropicResponse — LAC-2004
+// parseAnthropicResponse
 // ---------------------------------------------------------------------------
 
 test("parseAnthropicResponse: empty body produces zero windows", () => {
@@ -302,11 +313,13 @@ test("parseAnthropicResponse: empty body produces zero windows", () => {
 });
 
 test("parseAnthropicResponse: builds windows for every present field", () => {
+  // utilization is a whole percentage already (50 means 50%), not a 0..1
+  // fraction — see the 2026-08-03 regression note at the top of this file.
   const out = parseAnthropicResponse({
-    five_hour: { utilization: 0.5, resets_at: "2026-05-21T12:00:00Z" },
-    seven_day: { utilization: 0.25, resets_at: null },
-    seven_day_sonnet: { utilization: 0.1, resets_at: null },
-    seven_day_opus: { utilization: 0.9, resets_at: null },
+    five_hour: { utilization: 50, resets_at: "2026-05-21T12:00:00Z" },
+    seven_day: { utilization: 25, resets_at: null },
+    seven_day_sonnet: { utilization: 10, resets_at: null },
+    seven_day_opus: { utilization: 90, resets_at: null },
   });
   assert.deepEqual(
     out.map((w) => ({ label: w.label, usedPercent: w.usedPercent, resetsAt: w.resetsAt })),
@@ -319,9 +332,16 @@ test("parseAnthropicResponse: builds windows for every present field", () => {
   );
 });
 
-test("parseAnthropicResponse: 100% utilization round-trips to 100 (regression: LAC-2004)", () => {
+test("parseAnthropicResponse: low utilization stays low (regression: 2026-08-03)", () => {
   const out = parseAnthropicResponse({
     five_hour: { utilization: 1, resets_at: null },
+  });
+  assert.equal(out[0].usedPercent, 1);
+});
+
+test("parseAnthropicResponse: 100% utilization round-trips to 100", () => {
+  const out = parseAnthropicResponse({
+    five_hour: { utilization: 100, resets_at: null },
   });
   assert.equal(out[0].usedPercent, 100);
 });
@@ -343,7 +363,7 @@ test("parseAnthropicResponse: extra_usage enabled emits formatted currency label
       is_enabled: true,
       monthly_limit: 5000, // cents → $50.00
       used_credits: 1234, // cents → $12.34
-      utilization: 0.2468,
+      utilization: 24.68,
       currency: "USD",
     },
   });

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -30,9 +30,15 @@ export interface AnthropicUsageResponse {
   extra_usage?: AnthropicExtraUsage | null;
 }
 
+// The Anthropic OAuth usage API returns `utilization` as a whole percentage
+// already (1.0 means 1% used, not 100%) — confirmed against the same
+// response's own `limits[].percent` field, which reports the identical
+// value under an unambiguous name. An earlier version of this function
+// treated `utilization` as a 0..1 fraction and multiplied by 100, which
+// clamped any real (non-zero) usage straight to 100%.
 export function toPercent(utilization: number | null | undefined): number | null {
   if (utilization == null || !Number.isFinite(utilization)) return null;
-  return Math.max(0, Math.min(100, Math.round(utilization * 100)));
+  return Math.max(0, Math.min(100, Math.round(utilization)));
 }
 
 export function formatCurrency(value: number, currency: string | null | undefined): string {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -13,21 +13,22 @@ import {
   type ToolRunContext,
 } from "@paperclipai/plugin-sdk";
 import { DEFAULT_CONFIG, JOB_KEYS, STATE_KEYS, TOOL_NAMES } from "./constants.js";
-import { friendlyErrorMessage } from "./parsing.js";
+import {
+  type AnthropicUsageResponse,
+  type QuotaWindow,
+  cleanTerminalText,
+  extractAccountEmail,
+  formatTimeDelta,
+  friendlyErrorMessage,
+  parseAnthropicResponse,
+  parseClaudeCliUsageText,
+} from "./parsing.js";
 
 const execFileAsync = promisify(execFile);
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
-
-interface QuotaWindow {
-  label: string;
-  usedPercent: number | null;
-  resetsAt: string | null;
-  valueLabel: string | null;
-  detail: string | null;
-}
 
 interface ProviderSnapshot {
   provider: string;
@@ -52,105 +53,6 @@ interface PluginConfig {
 // ---------------------------------------------------------------------------
 // Anthropic OAuth Usage API
 // ---------------------------------------------------------------------------
-
-interface AnthropicUsageWindow {
-  utilization?: number | null;
-  resets_at?: string | null;
-}
-
-interface AnthropicExtraUsage {
-  is_enabled?: boolean | null;
-  monthly_limit?: number | null;
-  used_credits?: number | null;
-  utilization?: number | null;
-  currency?: string | null;
-}
-
-interface AnthropicUsageResponse {
-  five_hour?: AnthropicUsageWindow | null;
-  seven_day?: AnthropicUsageWindow | null;
-  seven_day_sonnet?: AnthropicUsageWindow | null;
-  seven_day_opus?: AnthropicUsageWindow | null;
-  extra_usage?: AnthropicExtraUsage | null;
-}
-
-function toPercent(utilization: number | null | undefined): number | null {
-  if (utilization == null || !Number.isFinite(utilization)) return null;
-  return Math.max(0, Math.min(100, Math.round(utilization * 100)));
-}
-
-function formatCurrency(value: number, currency: string | null | undefined): string {
-  const code =
-    typeof currency === "string" && currency.trim().length > 0
-      ? currency.trim().toUpperCase()
-      : "USD";
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: code,
-    maximumFractionDigits: 2,
-  }).format(value);
-}
-
-function parseAnthropicResponse(body: AnthropicUsageResponse): QuotaWindow[] {
-  const windows: QuotaWindow[] = [];
-
-  if (body.five_hour != null) {
-    windows.push({
-      label: "Current session (5h)",
-      usedPercent: toPercent(body.five_hour.utilization),
-      resetsAt: body.five_hour.resets_at ?? null,
-      valueLabel: null,
-      detail: null,
-    });
-  }
-  if (body.seven_day != null) {
-    windows.push({
-      label: "Week — all models",
-      usedPercent: toPercent(body.seven_day.utilization),
-      resetsAt: body.seven_day.resets_at ?? null,
-      valueLabel: null,
-      detail: null,
-    });
-  }
-  if (body.seven_day_sonnet != null) {
-    windows.push({
-      label: "Week — Sonnet",
-      usedPercent: toPercent(body.seven_day_sonnet.utilization),
-      resetsAt: body.seven_day_sonnet.resets_at ?? null,
-      valueLabel: null,
-      detail: null,
-    });
-  }
-  if (body.seven_day_opus != null) {
-    windows.push({
-      label: "Week — Opus",
-      usedPercent: toPercent(body.seven_day_opus.utilization),
-      resetsAt: body.seven_day_opus.resets_at ?? null,
-      valueLabel: null,
-      detail: null,
-    });
-  }
-  if (body.extra_usage != null) {
-    const eu = body.extra_usage;
-    let valueLabel: string | null = null;
-    if (
-      eu.is_enabled !== false &&
-      typeof eu.monthly_limit === "number" &&
-      typeof eu.used_credits === "number"
-    ) {
-      valueLabel = `${formatCurrency(eu.used_credits / 100, eu.currency)} / ${formatCurrency(eu.monthly_limit / 100, eu.currency)}`;
-    }
-    windows.push({
-      label: "Extra usage",
-      usedPercent: eu.is_enabled === false ? null : toPercent(eu.utilization),
-      resetsAt: null,
-      valueLabel: eu.is_enabled === false ? "Not enabled" : valueLabel,
-      detail: eu.is_enabled === false ? "Extra usage not enabled" : "Monthly extra usage pool",
-    });
-  }
-
-  return windows;
-}
 
 async function fetchAnthropicUsage(token: string): Promise<QuotaWindow[]> {
   const controller = new AbortController();
@@ -215,15 +117,6 @@ async function readLocalClaudeToken(): Promise<string | null> {
   return null;
 }
 
-function extractAccountEmail(parsed: unknown): string | null {
-  if (typeof parsed !== "object" || parsed === null) return null;
-  const account = (parsed as Record<string, unknown>)["oauthAccount"];
-  if (typeof account !== "object" || account === null) return null;
-  const email = (account as Record<string, unknown>)["emailAddress"];
-  if (typeof email === "string" && email.trim().length > 0) return email.trim();
-  return null;
-}
-
 // The signed-in account lives in Claude Code's main config (`.claude.json`),
 // which sits inside CLAUDE_CONFIG_DIR when that's set and at ~/.claude.json
 // otherwise — a different file from the credentials read above.
@@ -250,114 +143,6 @@ async function readLocalClaudeAccount(): Promise<string | null> {
 // ---------------------------------------------------------------------------
 // CLI fallback — spawns `claude /usage` and parses the terminal output
 // ---------------------------------------------------------------------------
-
-function stripBackspaces(text: string): string {
-  let out = "";
-  for (const char of text) {
-    if (char === "\b") {
-      out = out.slice(0, -1);
-    } else {
-      out += char;
-    }
-  }
-  return out;
-}
-
-function stripAnsi(text: string): string {
-  return text
-    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, "")
-    .replace(/\x1b(?:\[[0-?]*[ -/]*[@-~]|[@-Z\\-_])/g, "");
-}
-
-function cleanTerminalText(text: string): string {
-  return stripAnsi(stripBackspaces(text)).replace(/\r/g, "\n");
-}
-
-function normalizeForLabelSearch(text: string): string {
-  return text.toLowerCase().replace(/[^a-z0-9]+/g, "");
-}
-
-function trimToLatestUsagePanel(text: string): string | null {
-  const lower = text.toLowerCase();
-  const settingsIndex = lower.lastIndexOf("settings:");
-  if (settingsIndex < 0) return null;
-  const tail = text.slice(settingsIndex);
-  const tailLower = tail.toLowerCase();
-  if (!tailLower.includes("usage")) return null;
-  if (!tailLower.includes("current session") && !tailLower.includes("loading usage")) return null;
-  return tail;
-}
-
-function isQuotaLabel(line: string): boolean {
-  const n = normalizeForLabelSearch(line);
-  return n === "currentsession"
-    || n === "currentweekallmodels"
-    || n === "currentweeksonnetonly"
-    || n === "currentweeksonnet"
-    || n === "currentweekopusonly"
-    || n === "currentweekopus"
-    || n === "extrausage";
-}
-
-function canonicalQuotaLabel(line: string): string {
-  switch (normalizeForLabelSearch(line)) {
-    case "currentsession": return "Current session (5h)";
-    case "currentweekallmodels": return "Week — all models";
-    case "currentweeksonnetonly":
-    case "currentweeksonnet": return "Week — Sonnet";
-    case "currentweekopusonly":
-    case "currentweekopus": return "Week — Opus";
-    case "extrausage": return "Extra usage";
-    default: return line;
-  }
-}
-
-function percentFromLine(line: string): number | null {
-  const match = line.match(/([0-9]{1,3}(?:\.[0-9]+)?)\s*%/i);
-  if (!match) return null;
-  const rawValue = Number(match[1]);
-  if (!Number.isFinite(rawValue)) return null;
-  const clamped = Math.min(100, Math.max(0, rawValue));
-  const lower = line.toLowerCase();
-  if (lower.includes("remaining") || lower.includes("left") || lower.includes("available")) {
-    return Math.max(0, Math.min(100, Math.round(100 - clamped)));
-  }
-  return Math.round(clamped);
-}
-
-function parseClaudeCliUsageText(text: string): QuotaWindow[] {
-  const cleaned = trimToLatestUsagePanel(cleanTerminalText(text)) ?? cleanTerminalText(text);
-  const lines = cleaned.split("\n").map((l) => l.trim()).filter((l) => l.length > 0);
-
-  const sections: Array<{ label: string; lines: string[] }> = [];
-  let current: { label: string; lines: string[] } | null = null;
-
-  for (const line of lines) {
-    if (isQuotaLabel(line)) {
-      if (current) sections.push(current);
-      current = { label: canonicalQuotaLabel(line), lines: [] };
-      continue;
-    }
-    if (current) current.lines.push(line);
-  }
-  if (current) sections.push(current);
-
-  const windows = sections.map<QuotaWindow>((section) => {
-    const usedPercent = section.lines.map(percentFromLine).find((v) => v != null) ?? null;
-    return {
-      label: section.label,
-      usedPercent,
-      resetsAt: null,
-      valueLabel: null,
-      detail: null,
-    };
-  });
-
-  if (!windows.some((w) => normalizeForLabelSearch(w.label).includes("session"))) {
-    throw new Error("Could not parse Claude CLI usage output.");
-  }
-  return windows;
-}
 
 function createClaudeQuotaEnv(): Record<string, string> {
   const env: Record<string, string> = {};
@@ -521,16 +306,6 @@ async function runPollAndStore(ctx: PluginContext): Promise<ProviderSnapshot> {
 // ---------------------------------------------------------------------------
 // Human-readable summary for agent tool
 // ---------------------------------------------------------------------------
-
-function formatTimeDelta(isoDate: string): string {
-  const delta = new Date(isoDate).getTime() - Date.now();
-  if (delta <= 0) return "now";
-  const minutes = Math.round(delta / 60_000);
-  if (minutes < 60) return `${minutes}m`;
-  const hours = Math.round(minutes / 60);
-  if (hours < 24) return `${hours}h`;
-  return `${Math.round(hours / 24)}d`;
-}
 
 // Tool handlers treat a snapshot as stale when it's older than the configured
 // poll interval. Floored at 5 minutes so an aggressive `pollIntervalMinutes: 1`


### PR DESCRIPTION
## Summary

`toPercent()` reports the wrong usage percentage against the real Anthropic OAuth usage API (`GET /api/oauth/usage`).

It multiplies `utilization` by 100, assuming a `0..1` fraction — but the live API returns `utilization` as a whole percentage already (e.g. `1.0` means 1% used, `31.0` means 31% used). This was confirmed against the same response's own `limits[].percent` field, which reports the identical value under an unambiguous name. With the `* 100` in place, any real, non-zero usage clamps straight to 100% — the dashboard, usage page, and `get-usage`/`get-usage-summary` agent tools all report "100% used" for accounts that have barely touched their quota.

This reverses `toPercent`'s previous fix (the `LAC-2004` regression tests it added), which was chasing the opposite problem — reported `utilization: 1.0` displaying as 1% instead of 100% — under the wrong assumption about the API's units. Both bugs are real; the API's units just aren't what either fix assumed. The new regression test asserts against the values actually observed from a live low-usage account (1% / 31%), not synthetic 0..1 fractions.

While tracking this down, found the actual root cause of why the bug shipped silently: **`worker.ts` carries a full second copy of every helper in `parsing.ts`** — `toPercent`, `parseAnthropicResponse`, `extractAccountEmail`, the whole CLI-output parsing pipeline (`stripAnsi`, `cleanTerminalText`, `parseClaudeCliUsageText`, etc.) — and never imports from `parsing.ts` (only `friendlyErrorMessage` was actually wired up). `parsing.ts`'s own comment says these were "extracted from worker.ts so they can be unit-tested," but the extraction never got finished — the copy left behind in `worker.ts` is the one that actually runs, while `parsing.test.ts` exercises the untouched copy in `parsing.ts`. Any future fix to a `parsing.ts` function (like this one) silently does nothing to production behavior unless the same edit is manually mirrored into `worker.ts`.

This PR fixes `toPercent()` and removes the duplication so `parsing.ts` is the single source of truth `worker.ts` actually runs.

## How to test

```bash
npm install
npm run typecheck
npm run build
npm test
```

Or manually: connect a low-usage Claude account and check the dashboard widget / usage page report percentages that match `claude /usage` in the CLI, not 100%.

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run build` produces `dist/manifest.js` + `dist/worker.js`
- [ ] Updated the README if a public option or agent tool changed — n/a, no public option or tool changed
- [x] PR is focused (one logical change — the units bug and the duplication that hid it are the same root cause)