### PR TITLE
fix: resolve Claude OAuth token via secrets, remove non-functional settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Signed-in account email shown in the dashboard widget, usage page, settings page, and agent usage summary, so multi-account users can tell which account the quota belongs to (LAC-3028).
+- `claudeOAuthTokenRef` config field — a Claude OAuth token stored as a Paperclip secret, resolved via `ctx.secrets`. Needed because Paperclip's plugin worker processes deliberately don't inherit the host's environment (a security boundary against leaking unrelated host secrets), so a `CLAUDE_CODE_OAUTH_TOKEN` set on the Paperclip host/container itself is invisible to the plugin. Checked before the environment variable and the local credentials file/Keychain.
 
 - Centered README hero, logo (pink quota-bars on rounded square), 5 modern badges.
 - `.github/` community files: FUNDING, dependabot, ISSUE_TEMPLATE, PR template, SECURITY, CONTRIBUTING.
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Install code blocks switched from `bash` to `http` fence (matches the pseudo-HTTP REST shape).
 - PR template + CONTRIBUTING aligned with actual `npm run typecheck` / `npm run build` workflow.
 - npm keywords expanded (paperclip-plugin, ai, ai-agent, agent, quota, usage, tracking, oauth).
+- Removed the plugin's custom settings page. It was display-only (status text, no editable fields), and declaring a custom `settingsPage` slot suppresses Paperclip's own auto-generated config form — the only thing that renders a working secret picker for `claudeOAuthTokenRef`. There was previously no way to edit any setting through this plugin's UI. Status/account/source remain visible on the main **Agent Usage** page and dashboard widget.
 
 ## [0.1.4] and earlier
 

--- a/README.md
+++ b/README.md
@@ -76,9 +76,7 @@ Bars shift green → purple → red as usage approaches limits, so you spot trou
 
 ### Plugin settings
 
-Auto-detects your Claude OAuth credentials and shows current connection status.
-
-![Plugin settings](screenshots/agent-usage-settings-connected.png)
+Configuration lives on Paperclip's own generated settings form (Instance Settings → Plugins → Agent Usage Tracker), including a secret picker for the Claude OAuth token — this plugin doesn't ship a custom settings page, so that form is never hidden. Connection status (provider, account, token source) is shown on the main **Agent Usage** page and the dashboard widget instead.
 
 ## Configuration
 
@@ -86,8 +84,23 @@ Auto-detects your Claude OAuth credentials and shows current connection status.
 |---|---|---|
 | `pollIntervalMinutes` | How often to refresh usage data | `15` |
 | `providers` | Which providers to track | `["claude"]` |
+| `claudeOAuthTokenRef` | A Claude Code OAuth token (`claude setup-token`), stored as a Paperclip secret. Checked first. | *(unset)* |
 
-OAuth credentials are auto-detected from your local Claude install (`~/.claude` or macOS Keychain). Token lifecycle is managed by Paperclip.
+OAuth credentials are auto-detected in this order: the `claudeOAuthTokenRef`
+secret, the `CLAUDE_CODE_OAUTH_TOKEN` environment variable, then your local
+Claude install (`~/.claude` or macOS Keychain). Token lifecycle is managed by
+Paperclip.
+
+**If Paperclip runs the plugin worker in its own sandboxed process** (the
+default when Paperclip itself manages the plugin, not just a bare Node
+process) — the host does not pass its own environment through to plugin
+workers, by design, so `CLAUDE_CODE_OAUTH_TOKEN` being set on the Paperclip
+host/container itself is invisible to the plugin no matter how it's
+configured there. Set `claudeOAuthTokenRef` in this plugin's settings
+instead — it uses Paperclip's own secret store, resolved by the host at
+call time, and is the only mechanism that reaches the worker process under
+that sandboxing model. Generate a token with `claude setup-token`, then
+paste it into the secret picker for this field.
 
 ## Agent tools
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,13 +5,11 @@ export const PAGE_ROUTE = "agent-usage";
 export const SLOT_IDS = {
   page: "agent-usage-page",
   dashboardWidget: "agent-usage-dashboard-widget",
-  settingsPage: "agent-usage-settings-page",
 } as const;
 
 export const EXPORT_NAMES = {
   page: "AgentUsagePage",
   dashboardWidget: "AgentUsageDashboardWidget",
-  settingsPage: "AgentUsageSettingsPage",
 } as const;
 
 export const JOB_KEYS = {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -32,6 +32,7 @@ const manifest: PaperclipPluginManifestV1 = {
     "ui.dashboardWidget.register",
     "ui.page.register",
     "instance.settings.register",
+    "secrets.read-ref",
   ],
   entrypoints: {
     worker: "./dist/worker.js",
@@ -54,6 +55,20 @@ const manifest: PaperclipPluginManifestV1 = {
           enum: ["claude"],
         },
         default: DEFAULT_CONFIG.providers,
+      },
+      claudeOAuthTokenRef: {
+        // A secret-ref field's saved value is either a raw string (typed or
+        // pasted directly — the host converts it to a stored secret on
+        // save) or a structured { type: "secret_ref", secretId, version }
+        // object (bound to an existing/newly-created company secret via the
+        // picker). Declaring only "string" here rejects the second shape
+        // with "must be string" the moment an operator uses the picker
+        // instead of the raw-paste fallback.
+        type: ["string", "object"],
+        format: "secret-ref",
+        title: "Claude OAuth Token",
+        description:
+          "A Claude Code OAuth token (generate one with `claude setup-token`), stored as a Paperclip secret. Checked first, before any credentials file or CLAUDE_CODE_OAUTH_TOKEN environment variable — the only reliable option when Paperclip runs the plugin worker in its own sandboxed process without the host's environment.",
       },
     },
   },
@@ -101,12 +116,6 @@ const manifest: PaperclipPluginManifestV1 = {
         displayName: "Agent Usage",
         exportName: EXPORT_NAMES.page,
         routePath: PAGE_ROUTE,
-      },
-      {
-        type: "settingsPage",
-        id: SLOT_IDS.settingsPage,
-        displayName: "Agent Usage Settings",
-        exportName: EXPORT_NAMES.settingsPage,
       },
       {
         type: "dashboardWidget",

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -3,7 +3,6 @@ import {
   usePluginAction,
   usePluginData,
   type PluginPageProps,
-  type PluginSettingsPageProps,
   type PluginWidgetProps,
 } from "@paperclipai/plugin-sdk/ui";
 
@@ -773,76 +772,8 @@ function UsagePill({ percent }: { percent: number }) {
   );
 }
 
-// ---------------------------------------------------------------------------
-// Settings Page
-// ---------------------------------------------------------------------------
-
-export function AgentUsageSettingsPage(_props: PluginSettingsPageProps) {
-  const { data: snapshot } = usePluginData<ProviderSnapshot | null>(
-    "latest-quota",
-    {}
-  );
-
-  const statusColor = snapshot?.ok
-    ? t.ok
-    : snapshot?.error
-      ? t.destructive
-      : t.mutedFg;
-
-  const statusText = snapshot?.ok
-    ? `Connected — last fetch ${formatAge(snapshot.fetchedAt)}`
-    : snapshot?.error
-      ? snapshot.error
-      : "Not yet polled";
-
-  return (
-    <div style={base.container}>
-      <h3 style={base.heading}>Agent Usage Status</h3>
-      <p style={{ fontSize: "12px", color: t.mutedFg, marginBottom: "12px", marginTop: 0 }}>
-        OAuth credentials are auto-detected from your local Claude installation.
-      </p>
-
-      <div
-        style={{
-          padding: "10px 12px",
-          background: t.card,
-          border: `1px solid ${t.border}`,
-          borderRadius: "var(--radius, 0)",
-          fontSize: "12px",
-          display: "grid",
-          gap: "6px",
-        }}
-      >
-        <Row label="Status">
-          <span style={{ color: statusColor, fontWeight: 500 }}>{statusText}</span>
-        </Row>
-        <Row label="Provider">
-          <span style={{ color: t.fg }}>{snapshot?.provider ?? "—"}</span>
-        </Row>
-        <Row label="Account">
-          <span style={{ color: t.fg }}>{snapshot?.account ?? "—"}</span>
-        </Row>
-        <Row label="Token source">
-          <span style={{ color: t.fg }}>{snapshot?.source ?? "—"}</span>
-        </Row>
-      </div>
-    </div>
-  );
-}
-
-function Row({
-  label,
-  children,
-}: {
-  label: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div style={{ display: "flex", gap: "8px", alignItems: "baseline" }}>
-      <span style={{ color: t.mutedFg, minWidth: "96px", flexShrink: 0 }}>
-        {label}
-      </span>
-      {children}
-    </div>
-  );
-}
+// Settings editing lives on the host's auto-generated config form now (see
+// CHANGELOG) — this file no longer declares a custom settingsPage slot,
+// since doing so suppressed that form entirely, including its secret-picker
+// widget for claudeOAuthTokenRef. Status/account/source are already shown
+// on the main page above.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -6,6 +6,7 @@ import { promisify } from "node:util";
 import {
   definePlugin,
   runWorker,
+  type EnvSecretRefBinding,
   type PaperclipPlugin,
   type PluginContext,
   type PluginHealthDiagnostics,
@@ -47,6 +48,7 @@ interface UsageHistoryEntry {
 interface PluginConfig {
   pollIntervalMinutes?: number;
   providers?: string[];
+  claudeOAuthTokenRef?: string | EnvSecretRefBinding | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -181,7 +183,37 @@ function claudeConfigDir(): string {
   return path.join(os.homedir(), ".claude");
 }
 
-async function readLocalClaudeToken(): Promise<string | null> {
+async function readLocalClaudeToken(
+  secrets: Pick<PluginContext, "secrets">["secrets"],
+  tokenRef: PluginConfig["claudeOAuthTokenRef"],
+): Promise<string | null> {
+  // Checked first: an operator-configured secret ref (Claude OAuth Token
+  // setting). This is the only mechanism that actually works when Paperclip
+  // runs the plugin worker in its own sandboxed process — the host
+  // deliberately does not pass its own environment through to workers (to
+  // avoid leaking unrelated host secrets), so CLAUDE_CODE_OAUTH_TOKEN being
+  // set on the Paperclip container/host itself is invisible here regardless
+  // of what this function checks next. Resolving through ctx.secrets is the
+  // documented, supported path for a plugin to receive a value like that.
+  if (tokenRef) {
+    try {
+      const resolved = await secrets.resolve(tokenRef);
+      if (typeof resolved === "string" && resolved.trim().length > 0) {
+        return resolved.trim();
+      }
+    } catch {
+      // Ref set but not resolvable (deleted, revoked, no access) — fall through.
+    }
+  }
+
+  // The env var itself: kept as a fallback for non-sandboxed usage (running
+  // this worker outside Paperclip's process model, e.g. local development),
+  // where nothing strips the ambient environment.
+  const envToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+  if (typeof envToken === "string" && envToken.trim().length > 0) {
+    return envToken.trim();
+  }
+
   const configDir = claudeConfigDir();
   for (const filename of [".credentials.json", "credentials.json"]) {
     try {
@@ -454,7 +486,7 @@ async function runPollAndStore(ctx: PluginContext): Promise<ProviderSnapshot> {
 
   let snapshot: ProviderSnapshot;
   try {
-    const token = await readLocalClaudeToken();
+    const token = await readLocalClaudeToken(ctx.secrets, config.claudeOAuthTokenRef);
     let windows: QuotaWindow[];
     let source: string;
 


### PR DESCRIPTION
## Summary

Two related fixes found while running this plugin against a real, self-hosted Paperclip instance where Paperclip and the signed-in Claude Code user are not the same unsandboxed process.

**Adds a `claudeOAuthTokenRef` config field**, resolved through `ctx.secrets` at call time, checked before the `CLAUDE_CODE_OAUTH_TOKEN` environment variable and the local credentials file/Keychain. This reintroduces an operator-settable token — removed in #6 (LAC-1073) on the reasoning that "Paperclip agents run on the same machine as Claude — they share the same credentials... no reason to exist." That's true for the deployment shape LAC-1073 was written against, but doesn't hold for the one this plugin's own worker actually runs in by default: **Paperclip's plugin worker processes deliberately don't inherit the host's environment** (a real security boundary against leaking unrelated host secrets). A `CLAUDE_CODE_OAUTH_TOKEN` set on the Paperclip host/container itself is invisible to the plugin worker regardless of what it checks for — confirmed live against a real deployment. File/Keychain auto-detection still works fine when Paperclip and Claude Code run as the same unsandboxed user (the case LAC-1073 addressed); this fix covers the sandboxed case it didn't have visibility into. `secrets.read-ref` is the documented, supported path for a plugin to receive a value like this (PLUGIN_SPEC.md §22).

**Removes the plugin's custom settings page.** It's been display-only (status text, no editable fields) since it was first written — and declaring a custom `settingsPage` slot at all suppresses Paperclip's own auto-generated config form, which is the only thing that renders a working secret picker. There was no way to edit *any* setting through this plugin's UI before this change, for any field, only via direct API calls. Status/account/source stay visible on the main **Agent Usage** page and dashboard widget, which already duplicated this info.

The `claudeOAuthTokenRef` field declares `type: ["string", "object"]` rather than a bare `"string"` — the secret picker's "bind to a secret" path sends a structured `{ type: "secret_ref", secretId, version }` object on save, which a `"string"`-only schema rejects with a validation error the moment an operator uses the picker instead of raw-pasting a token.

## Dependency note

This requires an `@paperclipai/plugin-sdk` version with `EnvSecretRefBinding` / object-shaped `secrets.resolve()` support (confirmed present in `2026.722.0`, the version pinned by #52). This repo's currently-committed `package-lock.json` resolves `"latest"` to a stale `2026.517.0`, which predates that support — `npm run typecheck` will fail against it with `Module '"@paperclipai/plugin-sdk"' has no exported member 'EnvSecretRefBinding'` until #52 merges (that's the exact bug #52 fixes). Recommend merging #52 first and rebasing this PR, or merging in either order and re-running CI after both land.

## How to test

```bash
npm install
npm run typecheck
npm run build
npm test
```

Manually: set `claudeOAuthTokenRef` via the picker on Paperclip's generated settings form (not this plugin's own — it no longer has one), confirm the dashboard/usage page/tools report real data even when the plugin worker has no ambient environment.

## Checklist

- [x] `npm run typecheck` passes (against `@paperclipai/plugin-sdk@2026.722.0`; see dependency note above for the current lockfile)
- [x] `npm run build` produces `dist/manifest.js` + `dist/worker.js`
- [x] Updated the README — new `claudeOAuthTokenRef` field, sandboxed-worker explanation, settings-page removal note
- [x] PR is focused (one logical change — the token secret and the settings-page removal are the same root fix, since the settings page was blocking the secret picker)